### PR TITLE
sse4.1: Add missing explicit cast to __m128i*

### DIFF
--- a/simde/x86/sse4.1.h
+++ b/simde/x86/sse4.1.h
@@ -987,7 +987,7 @@ SIMDE__FUNCTION_ATTRIBUTES
 simde__m128i
 simde_mm_stream_load_si128 (const simde__m128i* mem_addr) {
 #if defined(SIMDE_SSE4_1_NATIVE)
-  return SIMDE__M128I_C(_mm_stream_load_si128((void*) &(mem_addr->n)));
+  return SIMDE__M128I_C(_mm_stream_load_si128((__m128i*)(void*) &(mem_addr->n)));
 #else
   return *mem_addr;
 #endif


### PR DESCRIPTION
Explicitly casting to __m128* on this line appears to be necessary to compile using clang or gcc when SIMDE_SSE4_1_NATIVE is defined.