### PR TITLE
travis: use YAML block format for a better visualization.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,37 +88,60 @@ before_install:
 ## so instead we use C/CXX_COMPILER, then copy the values to CC/CXX
 ## here (after Travis has set CC/CXX).
 ###
-- if [ "${C_COMPILER}" = "pgcc" ]; then
-    curl 'https://raw.githubusercontent.com/nemequ/pgi-travis/master/install-pgi.sh' | /bin/sh;
+- |
+  if [ "${C_COMPILER}" = "pgcc" ]; then
+    curl 'https://raw.githubusercontent.com/nemequ/pgi-travis/master/install-pgi.sh' | /bin/sh
   elif [ "${C_COMPILER}" = "emcc" ]; then
-    cd "${HOME}";
-    curl -L https://github.com/urho3d/emscripten-sdk/archive/master.tar.gz | tar zx;
-    . emscripten-sdk-master/emsdk_env.sh;
-    SIMDE_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${EMSDK}/emscripten/master/cmake/Modules/Platform/Emscripten.cmake -DDISABLE_X86=yes";
+    cd "${HOME}"
+    curl -L https://github.com/urho3d/emscripten-sdk/archive/master.tar.gz | tar zx
+    . emscripten-sdk-master/emsdk_env.sh
+    SIMDE_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${EMSDK}/emscripten/master/cmake/Modules/Platform/Emscripten.cmake -DDISABLE_X86=yes"
   elif [ "${C_COMPILER}" = "arm-linux-gnueabihf-gcc" ]; then
-    SIMDE_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/test/cmake/toolchain-arm-linux-gnueabihf.cmake";
+    SIMDE_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/test/cmake/toolchain-arm-linux-gnueabihf.cmake"
   elif [ "${C_COMPILER}" = "aarch64-linux-gnu-gcc" ]; then
-    SIMDE_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/test/cmake/toolchain-aarch64-linux-gnu.cmake";
+    SIMDE_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/test/cmake/toolchain-aarch64-linux-gnu.cmake"
   elif [ "${ARCH}" = "i686" ]; then
-    sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt install -y libc6:i386 libc6-dev:i386 gcc-8:i386 cpp-8:i386 binutils:i386 binutils-i686-linux-gnu:i386 && export GCOV="-x /usr/bin/gcov-8" ;
+    sudo dpkg --add-architecture i386 && \
+      sudo apt-get update && \
+      sudo apt install -y \
+        libc6:i386 \
+        libc6-dev:i386 \
+        gcc-8:i386 \
+        cpp-8:i386 \
+        binutils:i386 \
+        binutils-i686-linux-gnu:i386 && \
+      export GCOV="-x /usr/bin/gcov-8"
   fi
-- if [ -n "${C_COMPILER}" ]; then export CC="${C_COMPILER}"; fi
-- if [ -z "${BUILD_TYPE}" ]; then export BUILD_TYPE="Coverage"; fi
+- |
+  if [ -n "${C_COMPILER}" ]; then
+    export CC="${C_COMPILER}"
+  fi
+- |
+  if [ -z "${BUILD_TYPE}" ]; then
+    export BUILD_TYPE="Coverage"
+  fi
 - mkdir "${TRAVIS_BUILD_DIR}/test/build"
 - cd "${TRAVIS_BUILD_DIR}/test/build"
 
 script:
-- if [ -n "${C_COMPILER}" ]; then export CC="${C_COMPILER}"; fi
+- |
+  if [ -n "${C_COMPILER}" ]; then
+    export CC="${C_COMPILER}"
+  fi
 - cat /proc/cpuinfo || true
 - cmake .. -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_C_FLAGS="-DTRAVIS_CI ${CFLAGS}" ${SIMDE_CMAKE_ARGS}
 - make VERBOSE=1
-- if [ "${C_COMPILER}" = "arm-linux-gnueabihf-gcc" ]; then
-    qemu-arm ./run-tests;
+- |
+  if [ "${C_COMPILER}" = "arm-linux-gnueabihf-gcc" ]; then
+    qemu-arm ./run-tests
   elif [ "${C_COMPILER}" = "aarch64-linux-gnu-gcc" ]; then
-    qemu-aarch64 ./run-tests;
+    qemu-aarch64 ./run-tests
   else
-    ./run-tests ;
+    ./run-tests
   fi
 
 after_success:
-- if [ "${BUILD_TYPE}" = "Coverage" ]; then bash <(curl -s https://codecov.io/bash) -f '!*test-common.c' ${GCOV}; fi
+- |
+  if [ "${BUILD_TYPE}" = "Coverage" ]; then
+    bash <(curl -s https://codecov.io/bash) -f '!*test-common.c' ${GCOV}
+  fi


### PR DESCRIPTION
Let me send pull-request about `.travis.yml`.
I think that the YAML block format makes us see `.travis.yml` like a real shell script.

Reference: https://en.wikipedia.org/wiki/YAML#Basic_components

How do you think?
