### PR TITLE
include libstdc++.so.6 for armhf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,7 +145,7 @@ jobs:
     install:
     - sudo dpkg --add-architecture armhf
     - sudo apt-get update
-    - sudo apt-get -y install crossbuild-essential-armhf libc6:armhf
+    - sudo apt-get -y install crossbuild-essential-armhf libc6:armhf libstdc++6:armhf
 
   - name: emscripten
     compiler: emcc
@@ -170,7 +170,6 @@ jobs:
 
   allow_failures:
   - name: s390x
-  - name: arm32
 
 before_install:
 - cat /proc/cpuinfo || true

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -134,3 +134,7 @@ foreach(native native emul)
   target_link_libraries(run-tests simde-test-${native})
 endforeach(native native emul)
 target_compile_definitions(simde-test-emul PRIVATE SIMDE_NO_NATIVE)
+
+foreach(tst "/x86/mmx" "/x86/sse" "/x86/sse2" "/x86/sse3" "/x86/ssse3" "/x86/sse4.1" "/x86/sse4.2" "/x86/avx" "/x86/fma" "/x86/avx2")
+  add_test(NAME "${tst}/${variant}" COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:run-tests> "${tst}")
+endforeach()


### PR DESCRIPTION
And make arm32 mandatory to pass, now that it does