### PR TITLE
Add missing parenthesis in _mm_bsrli_si128 and _mm_srli_si128 defines.

### DIFF
--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -698,8 +698,8 @@ simde_mm_bsrli_si128 (simde__m128i a, const int imm8) {
 #endif
 #define simde_mm_srli_si128(a, imm8) simde_mm_bsrli_si128(a, imm8)
 #if defined(SIMDE_SSE2_ENABLE_NATIVE_ALIASES)
-#  define _mm_bsrli_si128(a, imm8) SIMDE__M128I_TO_NATIVE(simde_mm_bsrli_si128(SIMDE__M128I_FROM_NATIVE(a), (imm8))
-#  define _mm_srli_si128(a, imm8) SIMDE__M128I_TO_NATIVE(simde_mm_bsrli_si128(SIMDE__M128I_FROM_NATIVE(a), (imm8))
+#  define _mm_bsrli_si128(a, imm8) SIMDE__M128I_TO_NATIVE(simde_mm_bsrli_si128(SIMDE__M128I_FROM_NATIVE(a), (imm8)))
+#  define _mm_srli_si128(a, imm8) SIMDE__M128I_TO_NATIVE(simde_mm_bsrli_si128(SIMDE__M128I_FROM_NATIVE(a), (imm8)))
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES


### PR DESCRIPTION
Error showed up while using -DSIMDE_ENABLE_NATIVE_ALIASES .