### PR TITLE
Create .editorconfig to document coding standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Configuration file for EditorConfig
+# More information is available under http://EditorConfig.org
+
+# Ignore any other files further up in the file system
+root = true
+
+# Configuration for all files
+[*]
+# Enforce Unix style line endings (\n only)
+end_of_line = lf
+# Always end files with a blank line
+insert_final_newline = true
+# Force space characters for indentation
+indent_style = space
+# Always indent by 2 characters
+indent_size = 2
+# Remove whitespace characters at the end of line
+trim_trailing_whitespace = true


### PR DESCRIPTION
https://editorconfig.org/

Related to #93 

We could also add a shortcut using a tool that people could run locally or as part of a git submit hook

Options for that local reformatting include:
 1. `astyle -s2 $(find test simde -type f -name '*[ch]')` (also makes the brace style consistent, see http://astyle.sourceforge.net/astyle.html#_Basic_Brace_Styles for more options)
 2. [`uncrustify`](https://github.com/uncrustify/uncrustify) So many options!
 3. [`indent`](https://www.gnu.org/software/indent/)
 4. ['clang-format'](http://clang.llvm.org/docs/ClangFormat.html)