### PR TITLE
suggestion: drone: add arm32 clang-N cases.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,57 @@
+---
+kind: pipeline
+type: docker
+name: "clang-9 arm32"
+platform:
+  os: linux
+  arch: arm
+steps:
+  - name: test
+    image: ubuntu:bionic
+    environment:
+      CC: clang-9
+      CXX: clang++-9
+    commands:
+    - uname -m
+    - apt-get -yq update
+    - apt-get -yq install clang-9 cmake git-core make
+    - git submodule update --init --recursive
+    - mkdir test/build
+    - cd test/build
+    - cmake ..
+    - make -j
+    - ./run-tests
+trigger:
+  branch:
+    exclude:
+    - wip/*
+
+---
+kind: pipeline
+type: docker
+name: "clang-7 arm32"
+platform:
+  os: linux
+  arch: arm
+steps:
+  - name: test
+    image: ubuntu:bionic
+    environment:
+      CC: clang-7
+      CXX: clang++-7
+    commands:
+    - uname -m
+    - apt-get -yq update
+    - apt-get -yq install clang-7 cmake git-core make
+    - git submodule update --init --recursive
+    - mkdir test/build
+    - cd test/build
+    - cmake ..
+    - make -j
+    - ./run-tests
+    # `make` fails.
+    failure: ignore
+trigger:
+  branch:
+    exclude:
+    - wip/*


### PR DESCRIPTION
This PR is related to https://github.com/nemequ/simde/issues/75 .
I want to suggest using Drone CI to test clang arm32 cases for now.

As a initial setting, I added clang-9 and clang-7 arm32 cases.
Here is the result of my forked repository. You see some errors by `make -j` on the clang-7 case.
https://cloud.drone.io/junaruga/simde/10/2/2

```
+ make -j
...
/drone/src/test/x86/../../simde/x86/sse2.h:2344:54: error: no member named 'neon_f64' in 'simde__m128d_private'
...
```

This case is for clang-7.
But I observed the similar errors on clang-10 and clang-9 arm32 cases in Fedora project build system.
Later I will share it too.

For Drone CI, if you are interested in starting Drone CI, the way is just to go to https://drone.io/ , and enable it for this repository.

Drone CI has 2 type of the setting files `.drone.yml` and `.drone.star`.
You can switch the used file in the setting page. The default setting is `.drone.yml`.
But you see this PR's 2 cases has common parts. Because `.drone.yml` does not support like a `matrix` feature in Travis.
If we want to do like a `matrix` feature, we need to use `.drone.star` that has Starlark language syntax. Starlark is a Python-like script language. [1]

How do you think?

[1] https://docs.drone.io/pipeline/scripting/starlark/
