### PR TITLE
Avx2 blend

### DIFF
--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -408,6 +408,31 @@ for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
 
 SIMDE__FUNCTION_ATTRIBUTES
 simde__m256i
+simde_mm256_blend_epi32(simde__m256i a, simde__m256i b, const int imm8)
+    HEDLEY_REQUIRE_MSG((imm8 & 0xff) == imm8, "imm8 must be in range [0, 255]") {
+#if defined(SIMDE_AVX2_NATIVE)
+  return _mm256_blend_epi32(a, b, imm8);
+#else
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  SIMDE__VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+    r_.i32[i] = ((imm8 >> i) & 1) ? b_.i32[i] : a_.i32[i];
+  }
+
+  return simde__m256i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_AVX2_ENABLE_NATIVE_ALIASES)
+#  define _mm256_blend_epi32(a, b, imm8) simde_mm256_blend_epi32(a, b, imm8)
+#endif
+
+
+SIMDE__FUNCTION_ATTRIBUTES
+simde__m256i
 simde_mm256_blendv_epi8(simde__m256i a, simde__m256i b, simde__m256i mask) {
 #if defined(SIMDE_AVX2_NATIVE)
   return _mm256_blendv_epi8(a, b, mask);

--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -408,6 +408,31 @@ for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
 
 SIMDE__FUNCTION_ATTRIBUTES
 simde__m256i
+simde_mm256_blend_epi16(simde__m256i a, simde__m256i b, const int imm8)
+    HEDLEY_REQUIRE_MSG((imm8 & 0xff) == imm8, "imm8 must be in range [0, 255]") {
+#if defined(SIMDE_AVX2_NATIVE)
+  return _mm256_blend_epi16(a, b, imm8);
+#else
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  SIMDE__VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+    r_.i16[i] = ((imm8 >> i%8) & 1) ? b_.i16[i] : a_.i16[i];
+  }
+
+  return simde__m256i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_AVX2_ENABLE_NATIVE_ALIASES)
+#  define _mm256_blend_epi16(a, b, imm8) simde_mm256_blend_epi16(a, b, imm8)
+#endif
+
+
+SIMDE__FUNCTION_ATTRIBUTES
+simde__m256i
 simde_mm256_blend_epi32(simde__m256i a, simde__m256i b, const int imm8)
     HEDLEY_REQUIRE_MSG((imm8 & 0xff) == imm8, "imm8 must be in range [0, 255]") {
 #if defined(SIMDE_AVX2_NATIVE)

--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -1654,7 +1654,7 @@ simde_mm256_slli_epi64 (simde__m256i a, const int imm8)
 #if defined(SIMDE_AVX2_ENABLE_NATIVE_ALIASES)
 #  define _mm256_slli_epi64(a, imm8) simde_mm256_slli_epi64(a, imm8)
 #endif
-     
+
 SIMDE__FUNCTION_ATTRIBUTES
 simde__m256i
 simde_mm256_sub_epi8 (simde__m256i a, simde__m256i b) {
@@ -2008,6 +2008,30 @@ simde_mm256_srli_epi32 (simde__m256i a, const int imm8) {
 #endif
 #if defined(SIMDE_AVX2_ENABLE_NATIVE_ALIASES)
 #  define _mm256_srli_epi32(a, imm8) simde_mm256_srli_epi32(a, imm8)
+#endif
+
+SIMDE__FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_blend_epi32(simde__m128i a, simde__m128i b, const int imm8)
+    HEDLEY_REQUIRE_MSG((imm8 & 0xff) == imm8, "imm8 must be in range [0, 255]") {
+#if defined(SIMDE_AVX2_NATIVE)
+  return _mm_blend_epi32(a, b, imm8);
+#else
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  SIMDE__VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+    r_.i32[i] = ((imm8 >> i) & 1) ? b_.i32[i] : a_.i32[i];
+  }
+
+  return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_AVX2_ENABLE_NATIVE_ALIASES)
+#  define _mm_blend_epi32(a, b, imm8) simde_mm_blend_epi32(a, b, imm8)
 #endif
 
 SIMDE__END_DECLS

--- a/test/x86/avx2.c
+++ b/test/x86/avx2.c
@@ -2132,6 +2132,74 @@ test_simde_mm256_adds_epu16(const MunitParameter params[], void* data) {
 }
 
 static MunitResult
+test_simde_mm256_blend_epi32(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__m256i a;
+    simde__m256i b;
+    simde__m256i r;
+  } test_vec[8] = {
+    { simde_mm256_set_epi32(INT32_C(   67571941), INT32_C(-1405773426), INT32_C( 1540271825), INT32_C( 2065572299),
+                            INT32_C( -582398487), INT32_C( 1269568238), INT32_C( -277360429), INT32_C(  355946014)),
+      simde_mm256_set_epi32(INT32_C(-1175528322), INT32_C( -128390122), INT32_C( 1870386786), INT32_C( 1369967555),
+                            INT32_C(  417868105), INT32_C(  128490599), INT32_C( 1283738263), INT32_C( -937782732)),
+      simde_mm256_set_epi32(INT32_C(   67571941), INT32_C(-1405773426), INT32_C( 1540271825), INT32_C( 2065572299),
+                            INT32_C(  417868105), INT32_C(  128490599), INT32_C( -277360429), INT32_C( -937782732)) },
+    { simde_mm256_set_epi32(INT32_C( 1471616457), INT32_C(  153196965), INT32_C(  177786947), INT32_C(-1953704859),
+                            INT32_C(-2052334624), INT32_C(-1985445584), INT32_C(  389650479), INT32_C(-1304302924)),
+      simde_mm256_set_epi32(INT32_C( -934897433), INT32_C( 1646862966), INT32_C(-1085276514), INT32_C(  112227015),
+                            INT32_C(-1389537102), INT32_C(  687724210), INT32_C( 1265543631), INT32_C(  346850755)),
+      simde_mm256_set_epi32(INT32_C( 1471616457), INT32_C(  153196965), INT32_C(  177786947), INT32_C(-1953704859),
+                            INT32_C(-1389537102), INT32_C(  687724210), INT32_C(  389650479), INT32_C(  346850755)) },
+    { simde_mm256_set_epi32(INT32_C(-1682060225), INT32_C(  867867583), INT32_C(  925546319), INT32_C( 1379938785),
+                            INT32_C(  653018322), INT32_C( -687296073), INT32_C( -911101701), INT32_C( 1547072378)),
+      simde_mm256_set_epi32(INT32_C( 1176167258), INT32_C( -301183666), INT32_C( -466020487), INT32_C(   52703344),
+                            INT32_C( 1233020389), INT32_C( 1117532027), INT32_C( 1899739665), INT32_C(-2043295118)),
+      simde_mm256_set_epi32(INT32_C(-1682060225), INT32_C(  867867583), INT32_C(  925546319), INT32_C( 1379938785),
+                            INT32_C( 1233020389), INT32_C( 1117532027), INT32_C( -911101701), INT32_C(-2043295118)) },
+    { simde_mm256_set_epi32(INT32_C(  359138398), INT32_C( -860526519), INT32_C( 1692947884), INT32_C(  772823662),
+                            INT32_C( -270939677), INT32_C( 1412661540), INT32_C( 1070011153), INT32_C(  771375046)),
+      simde_mm256_set_epi32(INT32_C( -974034130), INT32_C(   37087187), INT32_C( -871436522), INT32_C(   33095078),
+                            INT32_C(  715849450), INT32_C(-1345812415), INT32_C(  -45115049), INT32_C( 1960320081)),
+      simde_mm256_set_epi32(INT32_C(  359138398), INT32_C( -860526519), INT32_C( 1692947884), INT32_C(  772823662),
+                            INT32_C(  715849450), INT32_C(-1345812415), INT32_C( 1070011153), INT32_C( 1960320081)) },
+    { simde_mm256_set_epi32(INT32_C( -426383461), INT32_C( -768942960), INT32_C( -264677869), INT32_C( -822820045),
+                            INT32_C( 1890345084), INT32_C(-2046745025), INT32_C( -207573670), INT32_C( 1399666591)),
+      simde_mm256_set_epi32(INT32_C(  232105709), INT32_C(-1583898310), INT32_C( 1161298300), INT32_C(  169359829),
+                            INT32_C(  621794425), INT32_C(  607256107), INT32_C( 1099667121), INT32_C( -184390486)),
+      simde_mm256_set_epi32(INT32_C( -426383461), INT32_C( -768942960), INT32_C( -264677869), INT32_C( -822820045),
+                            INT32_C(  621794425), INT32_C(  607256107), INT32_C( -207573670), INT32_C( -184390486)) },
+    { simde_mm256_set_epi32(INT32_C(-1564290184), INT32_C( -240378472), INT32_C( 1142270593), INT32_C( 1000191111),
+                            INT32_C(   20701140), INT32_C(   37555352), INT32_C( -694404400), INT32_C( 1055280730)),
+      simde_mm256_set_epi32(INT32_C( 1835031057), INT32_C( 2079483638), INT32_C( 1962415366), INT32_C( -373228817),
+                            INT32_C(  142245442), INT32_C(   51427720), INT32_C( 1717201652), INT32_C( 1177983710)),
+      simde_mm256_set_epi32(INT32_C(-1564290184), INT32_C( -240378472), INT32_C( 1142270593), INT32_C( 1000191111),
+                            INT32_C(  142245442), INT32_C(   51427720), INT32_C( -694404400), INT32_C( 1177983710)) },
+    { simde_mm256_set_epi32(INT32_C(-1384452546), INT32_C( -108099055), INT32_C(   -3256672), INT32_C(-2139665218),
+                            INT32_C( -280826539), INT32_C( -885573478), INT32_C( 2104257473), INT32_C( 1279376382)),
+      simde_mm256_set_epi32(INT32_C( 1706246197), INT32_C(-1331652281), INT32_C( 1192842905), INT32_C( -885790109),
+                            INT32_C(-1010846518), INT32_C( -536721191), INT32_C( 1967911533), INT32_C( 1933417937)),
+      simde_mm256_set_epi32(INT32_C(-1384452546), INT32_C( -108099055), INT32_C(   -3256672), INT32_C(-2139665218),
+                            INT32_C(-1010846518), INT32_C( -536721191), INT32_C( 2104257473), INT32_C( 1933417937)) },
+    { simde_mm256_set_epi32(INT32_C( 1532802072), INT32_C(  125283422), INT32_C(-1578036874), INT32_C(  445027764),
+                            INT32_C( -409254011), INT32_C( 1098938926), INT32_C(-1086732528), INT32_C( -812360922)),
+      simde_mm256_set_epi32(INT32_C( 1974078859), INT32_C( 2037136311), INT32_C( 1463878416), INT32_C(  122656324),
+                            INT32_C(-2126065903), INT32_C(-1726635542), INT32_C(-1755031182), INT32_C( 1725515904)),
+      simde_mm256_set_epi32(INT32_C( 1532802072), INT32_C(  125283422), INT32_C(-1578036874), INT32_C(  445027764),
+                            INT32_C(-2126065903), INT32_C(-1726635542), INT32_C(-1086732528), INT32_C( 1725515904)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m256i r = simde_mm256_blend_epi32(test_vec[i].a, test_vec[i].b, 13);
+    simde_assert_m256i_i32(r, ==, test_vec[i].r);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
 test_simde_mm256_blendv_epi8(const MunitParameter params[], void* data) {
   (void) params;
   (void) data;
@@ -8066,6 +8134,7 @@ static MunitTest test_suite_tests[] = {
   SIMDE_TESTS_DEFINE_TEST(mm256_and_si256),
   SIMDE_TESTS_DEFINE_TEST(mm256_andnot_si256),
 
+  SIMDE_TESTS_DEFINE_TEST(mm256_blend_epi32),
   SIMDE_TESTS_DEFINE_TEST(mm256_blendv_epi8),
 
   SIMDE_TESTS_DEFINE_TEST(mm256_broadcastsi128_si256),

--- a/test/x86/avx2.c
+++ b/test/x86/avx2.c
@@ -2132,6 +2132,122 @@ test_simde_mm256_adds_epu16(const MunitParameter params[], void* data) {
 }
 
 static MunitResult
+test_simde_mm256_blend_epi16(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__m256i a;
+    simde__m256i b;
+    simde__m256i r;
+  } test_vec[8] = {
+    { simde_mm256_set_epi16(INT16_C( -9012), INT16_C( 17188), INT16_C( 20170), INT16_C( -6948),
+                            INT16_C(  9138), INT16_C( 24690), INT16_C( -6761), INT16_C( -2618),
+                            INT16_C( 30583), INT16_C(  3343), INT16_C( -2458), INT16_C( 32235),
+                            INT16_C(-14188), INT16_C( 15906), INT16_C(-17823), INT16_C(  7319)),
+      simde_mm256_set_epi16(INT16_C( -5752), INT16_C(-23668), INT16_C(-25159), INT16_C(-19782),
+                            INT16_C( 28185), INT16_C(-14343), INT16_C(-18599), INT16_C(   827),
+                            INT16_C( -4902), INT16_C(  2482), INT16_C( 14836), INT16_C(-27028),
+                            INT16_C( 23821), INT16_C( -1365), INT16_C( -4235), INT16_C(  -888)),
+      simde_mm256_set_epi16(INT16_C( -9012), INT16_C( 17188), INT16_C( 20170), INT16_C( -6948),
+                            INT16_C( 28185), INT16_C(-14343), INT16_C( -6761), INT16_C(   827),
+                            INT16_C( 30583), INT16_C(  3343), INT16_C( -2458), INT16_C( 32235),
+                            INT16_C( 23821), INT16_C( -1365), INT16_C(-17823), INT16_C(  -888)) },
+    { simde_mm256_set_epi16(INT16_C(  2208), INT16_C( 24143), INT16_C( 20623), INT16_C( -5907),
+                            INT16_C(  4359), INT16_C(  6016), INT16_C(  2606), INT16_C(-17968),
+                            INT16_C( 24878), INT16_C(-20974), INT16_C( 11542), INT16_C( 18923),
+                            INT16_C( 32276), INT16_C(-26730), INT16_C( 20467), INT16_C(-30404)),
+      simde_mm256_set_epi16(INT16_C( 27588), INT16_C(-23388), INT16_C( 31848), INT16_C( 22463),
+                            INT16_C(-31474), INT16_C(-14474), INT16_C(  2006), INT16_C(-32634),
+                            INT16_C( 32036), INT16_C(-13145), INT16_C(-30339), INT16_C(-22528),
+                            INT16_C( 17597), INT16_C( 17800), INT16_C( 16042), INT16_C( 23637)),
+      simde_mm256_set_epi16(INT16_C(  2208), INT16_C( 24143), INT16_C( 20623), INT16_C( -5907),
+                            INT16_C(-31474), INT16_C(-14474), INT16_C(  2606), INT16_C(-32634),
+                            INT16_C( 24878), INT16_C(-20974), INT16_C( 11542), INT16_C( 18923),
+                            INT16_C( 17597), INT16_C( 17800), INT16_C( 20467), INT16_C( 23637)) },
+    { simde_mm256_set_epi16(INT16_C(-30302), INT16_C( -3491), INT16_C(-12187), INT16_C( -9390),
+                            INT16_C( -5875), INT16_C(  4739), INT16_C( 19577), INT16_C(  7526),
+                            INT16_C( 31347), INT16_C( 10086), INT16_C(-16595), INT16_C( 27410),
+                            INT16_C(  1134), INT16_C(-11806), INT16_C(-16010), INT16_C(-25451)),
+      simde_mm256_set_epi16(INT16_C(-29901), INT16_C( 18434), INT16_C(  -841), INT16_C( 28759),
+                            INT16_C( -1918), INT16_C(  2817), INT16_C(-31249), INT16_C(  6853),
+                            INT16_C( 24735), INT16_C(-25824), INT16_C( -1496), INT16_C( 12880),
+                            INT16_C( 11586), INT16_C( 24977), INT16_C( 22341), INT16_C(-21470)),
+      simde_mm256_set_epi16(INT16_C(-30302), INT16_C( -3491), INT16_C(-12187), INT16_C( -9390),
+                            INT16_C( -1918), INT16_C(  2817), INT16_C( 19577), INT16_C(  6853),
+                            INT16_C( 31347), INT16_C( 10086), INT16_C(-16595), INT16_C( 27410),
+                            INT16_C( 11586), INT16_C( 24977), INT16_C(-16010), INT16_C(-21470)) },
+    { simde_mm256_set_epi16(INT16_C( 17074), INT16_C(-20924), INT16_C( 13898), INT16_C( 20227),
+                            INT16_C( 12334), INT16_C(-15702), INT16_C( 28564), INT16_C(-15082),
+                            INT16_C(-19676), INT16_C(   796), INT16_C( 13442), INT16_C( -9023),
+                            INT16_C( 10428), INT16_C( 21588), INT16_C(-25545), INT16_C( 22589)),
+      simde_mm256_set_epi16(INT16_C( 13365), INT16_C(-16397), INT16_C(-14658), INT16_C(  8081),
+                            INT16_C(  4626), INT16_C(-31038), INT16_C(-27498), INT16_C( -1797),
+                            INT16_C(-14919), INT16_C( 31584), INT16_C( 32162), INT16_C( 21664),
+                            INT16_C( 32327), INT16_C(  9046), INT16_C( 29457), INT16_C( 18165)),
+      simde_mm256_set_epi16(INT16_C( 17074), INT16_C(-20924), INT16_C( 13898), INT16_C( 20227),
+                            INT16_C(  4626), INT16_C(-31038), INT16_C( 28564), INT16_C( -1797),
+                            INT16_C(-19676), INT16_C(   796), INT16_C( 13442), INT16_C( -9023),
+                            INT16_C( 32327), INT16_C(  9046), INT16_C(-25545), INT16_C( 18165)) },
+    { simde_mm256_set_epi16(INT16_C(-28976), INT16_C(-17452), INT16_C(-30835), INT16_C(-11288),
+                            INT16_C( 23746), INT16_C(-12398), INT16_C( -9605), INT16_C(   914),
+                            INT16_C( -6067), INT16_C(  4660), INT16_C( 15780), INT16_C( 30375),
+                            INT16_C(-32484), INT16_C( 23271), INT16_C(-15980), INT16_C(  3969)),
+      simde_mm256_set_epi16(INT16_C(-14502), INT16_C(-26489), INT16_C( -6738), INT16_C( -1193),
+                            INT16_C( 15756), INT16_C(-12605), INT16_C(-12710), INT16_C( -8558),
+                            INT16_C( 19027), INT16_C(-19772), INT16_C( 23814), INT16_C(-30071),
+                            INT16_C(-29678), INT16_C( 31649), INT16_C(  4669), INT16_C( -4491)),
+      simde_mm256_set_epi16(INT16_C(-28976), INT16_C(-17452), INT16_C(-30835), INT16_C(-11288),
+                            INT16_C( 15756), INT16_C(-12605), INT16_C( -9605), INT16_C( -8558),
+                            INT16_C( -6067), INT16_C(  4660), INT16_C( 15780), INT16_C( 30375),
+                            INT16_C(-29678), INT16_C( 31649), INT16_C(-15980), INT16_C( -4491)) },
+    { simde_mm256_set_epi16(INT16_C( 16416), INT16_C(-25375), INT16_C(-21092), INT16_C(-20302),
+                            INT16_C(-10725), INT16_C(-20142), INT16_C( -4818), INT16_C(-14140),
+                            INT16_C(-13625), INT16_C(-24584), INT16_C(  6087), INT16_C(-31850),
+                            INT16_C(-29507), INT16_C(  7132), INT16_C( -6862), INT16_C( 26102)),
+      simde_mm256_set_epi16(INT16_C(  3513), INT16_C(-30455), INT16_C(-14215), INT16_C(-31390),
+                            INT16_C( 22371), INT16_C(-30450), INT16_C(-14197), INT16_C( -3991),
+                            INT16_C( 25198), INT16_C( -1251), INT16_C( -4992), INT16_C(-16295),
+                            INT16_C( 23622), INT16_C( 28506), INT16_C(-16087), INT16_C(-18392)),
+      simde_mm256_set_epi16(INT16_C( 16416), INT16_C(-25375), INT16_C(-21092), INT16_C(-20302),
+                            INT16_C( 22371), INT16_C(-30450), INT16_C( -4818), INT16_C( -3991),
+                            INT16_C(-13625), INT16_C(-24584), INT16_C(  6087), INT16_C(-31850),
+                            INT16_C( 23622), INT16_C( 28506), INT16_C( -6862), INT16_C(-18392)) },
+    { simde_mm256_set_epi16(INT16_C( -2375), INT16_C(  3031), INT16_C( 26231), INT16_C(  5999),
+                            INT16_C(-10519), INT16_C( 21791), INT16_C(  3889), INT16_C( 28062),
+                            INT16_C(-23674), INT16_C(-25444), INT16_C( 16907), INT16_C( 20389),
+                            INT16_C(-22712), INT16_C(   486), INT16_C( -2776), INT16_C(-21644)),
+      simde_mm256_set_epi16(INT16_C(-29652), INT16_C(   489), INT16_C( -7346), INT16_C(-13391),
+                            INT16_C( 21827), INT16_C(  9877), INT16_C(  7842), INT16_C(-13219),
+                            INT16_C( 12847), INT16_C( 31187), INT16_C( -8174), INT16_C( -7953),
+                            INT16_C(  8071), INT16_C(-19051), INT16_C( 30976), INT16_C( 20848)),
+      simde_mm256_set_epi16(INT16_C( -2375), INT16_C(  3031), INT16_C( 26231), INT16_C(  5999),
+                            INT16_C( 21827), INT16_C(  9877), INT16_C(  3889), INT16_C(-13219),
+                            INT16_C(-23674), INT16_C(-25444), INT16_C( 16907), INT16_C( 20389),
+                            INT16_C(  8071), INT16_C(-19051), INT16_C( -2776), INT16_C( 20848)) },
+    { simde_mm256_set_epi16(INT16_C( 13214), INT16_C(-27703), INT16_C(  6386), INT16_C(  5153),
+                            INT16_C( 26096), INT16_C(  8476), INT16_C( 10527), INT16_C(-23224),
+                            INT16_C( 23690), INT16_C(  9355), INT16_C(  1283), INT16_C(-29402),
+                            INT16_C( 22593), INT16_C(-12032), INT16_C( -8259), INT16_C( 13457)),
+      simde_mm256_set_epi16(INT16_C(-25352), INT16_C( 21231), INT16_C(-11795), INT16_C( 17700),
+                            INT16_C(-24048), INT16_C(-11558), INT16_C( -1645), INT16_C( 21362),
+                            INT16_C( 18474), INT16_C( 30559), INT16_C(  -790), INT16_C( 30067),
+                            INT16_C(  3488), INT16_C(  3834), INT16_C(  2645), INT16_C(-14787)),
+      simde_mm256_set_epi16(INT16_C( 13214), INT16_C(-27703), INT16_C(  6386), INT16_C(  5153),
+                            INT16_C(-24048), INT16_C(-11558), INT16_C( 10527), INT16_C( 21362),
+                            INT16_C( 23690), INT16_C(  9355), INT16_C(  1283), INT16_C(-29402),
+                            INT16_C(  3488), INT16_C(  3834), INT16_C( -8259), INT16_C(-14787)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m256i r = simde_mm256_blend_epi16(test_vec[i].a, test_vec[i].b, 13);
+    simde_assert_m256i_i16(r, ==, test_vec[i].r);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
 test_simde_mm256_blend_epi32(const MunitParameter params[], void* data) {
   (void) params;
   (void) data;
@@ -8134,6 +8250,7 @@ static MunitTest test_suite_tests[] = {
   SIMDE_TESTS_DEFINE_TEST(mm256_and_si256),
   SIMDE_TESTS_DEFINE_TEST(mm256_andnot_si256),
 
+  SIMDE_TESTS_DEFINE_TEST(mm256_blend_epi16),
   SIMDE_TESTS_DEFINE_TEST(mm256_blend_epi32),
   SIMDE_TESTS_DEFINE_TEST(mm256_blendv_epi8),
 

--- a/test/x86/avx2.c
+++ b/test/x86/avx2.c
@@ -8224,6 +8224,50 @@ test_simde_mm256_max_epu32(const MunitParameter params[], void* data) {
   return MUNIT_OK;
 }
 
+static MunitResult
+test_simde_mm_blend_epi32(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__m128i a;
+    simde__m128i b;
+    simde__m128i r;
+  } test_vec[8] = {
+    { simde_mm_set_epi32(INT32_C( -776446699), INT32_C( 1736036449), INT32_C( 1358627972), INT32_C(-1414521748)),
+      simde_mm_set_epi32(INT32_C(  703500470), INT32_C(-1252293011), INT32_C(-1142834240), INT32_C( 1567373213)),
+      simde_mm_set_epi32(INT32_C(  703500470), INT32_C(-1252293011), INT32_C( 1358627972), INT32_C( 1567373213)) },
+    { simde_mm_set_epi32(INT32_C(  928555701), INT32_C( -221570804), INT32_C( 1766167688), INT32_C( 1538455167)),
+      simde_mm_set_epi32(INT32_C(-2064241406), INT32_C(-1114629780), INT32_C(  844778923), INT32_C(  825239814)),
+      simde_mm_set_epi32(INT32_C(-2064241406), INT32_C(-1114629780), INT32_C( 1766167688), INT32_C(  825239814)) },
+    { simde_mm_set_epi32(INT32_C( -254776787), INT32_C(-1383921861), INT32_C(-1381573747), INT32_C(  385374117)),
+      simde_mm_set_epi32(INT32_C(  783537896), INT32_C( -226088253), INT32_C( 1138968651), INT32_C(  521443914)),
+      simde_mm_set_epi32(INT32_C(  783537896), INT32_C( -226088253), INT32_C(-1381573747), INT32_C(  521443914)) },
+    { simde_mm_set_epi32(INT32_C(  484740492), INT32_C(-1346417719), INT32_C( 1029792501), INT32_C( 2033188015)),
+      simde_mm_set_epi32(INT32_C(  465252472), INT32_C( -775119562), INT32_C( 1616675771), INT32_C(-1846026054)),
+      simde_mm_set_epi32(INT32_C(  465252472), INT32_C( -775119562), INT32_C( 1029792501), INT32_C(-1846026054)) },
+    { simde_mm_set_epi32(INT32_C( 2097910720), INT32_C(  985021972), INT32_C(-1164844515), INT32_C(-1048926956)),
+      simde_mm_set_epi32(INT32_C( 1235766570), INT32_C( 1912005813), INT32_C( -678890313), INT32_C( -799232173)),
+      simde_mm_set_epi32(INT32_C( 1235766570), INT32_C( 1912005813), INT32_C(-1164844515), INT32_C( -799232173)) },
+    { simde_mm_set_epi32(INT32_C(  107952418), INT32_C(-1186034132), INT32_C(-1490121281), INT32_C(-1988190971)),
+      simde_mm_set_epi32(INT32_C(  438665972), INT32_C(-1023182690), INT32_C(-1692406594), INT32_C( 2076129119)),
+      simde_mm_set_epi32(INT32_C(  438665972), INT32_C(-1023182690), INT32_C(-1490121281), INT32_C( 2076129119)) },
+    { simde_mm_set_epi32(INT32_C( -296997195), INT32_C( 1989906045), INT32_C(  861414748), INT32_C(  802028810)),
+      simde_mm_set_epi32(INT32_C( 2010137226), INT32_C(-1001536035), INT32_C(  526065654), INT32_C( 2146580357)),
+      simde_mm_set_epi32(INT32_C( 2010137226), INT32_C(-1001536035), INT32_C(  861414748), INT32_C( 2146580357)) },
+    { simde_mm_set_epi32(INT32_C( 1671679906), INT32_C(   72341521), INT32_C(  697290912), INT32_C( 1581591761)),
+      simde_mm_set_epi32(INT32_C( -765500720), INT32_C(  807300453), INT32_C(-1774452228), INT32_C( -386626305)),
+      simde_mm_set_epi32(INT32_C( -765500720), INT32_C(  807300453), INT32_C(  697290912), INT32_C( -386626305)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m128i r = simde_mm_blend_epi32(test_vec[i].a, test_vec[i].b, 13);
+    simde_assert_m128i_i32(r, ==, test_vec[i].r);
+  }
+
+  return MUNIT_OK;
+}
+
 
 #endif /* defined(SIMDE_AVX2_NATIVE) || defined(SIMDE_NO_NATIVE) || defined(SIMDE_ALWAYS_BUILD_NATIVE_TESTS) */
 
@@ -8250,6 +8294,7 @@ static MunitTest test_suite_tests[] = {
   SIMDE_TESTS_DEFINE_TEST(mm256_and_si256),
   SIMDE_TESTS_DEFINE_TEST(mm256_andnot_si256),
 
+  SIMDE_TESTS_DEFINE_TEST(mm_blend_epi32),
   SIMDE_TESTS_DEFINE_TEST(mm256_blend_epi16),
   SIMDE_TESTS_DEFINE_TEST(mm256_blend_epi32),
   SIMDE_TESTS_DEFINE_TEST(mm256_blendv_epi8),


### PR DESCRIPTION
`mm256_blend_epi32` is needed for https://tracker.debian.org/pkg/kalign