### PR TITLE
Fix type for argument 3 in _mm_maskmoveu_si128

### DIFF
--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -2893,7 +2893,7 @@ simde_mm_maskmoveu_si128 (simde__m128i a, simde__m128i mask, int8_t mem_addr[HED
 #endif
 }
 #if defined(SIMDE_SSE2_ENABLE_NATIVE_ALIASES)
-#  define _mm_maskmoveu_si128(a, mask, mem_addr) simde_mm_maskmoveu_si128(a, (mask), mem_addr)
+#  define _mm_maskmoveu_si128(a, mask, mem_addr) simde_mm_maskmoveu_si128(a, (mask), (int8_t*)mem_addr)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES


### PR DESCRIPTION
Fix type for argument 3 in simde_mm_maskmoveu_si128 when using native aliases. The Intel intrinsic is declared as taking a 'char*' and we must therefore cast in order to redirect to the simde version