### PR TITLE
Change fundamental types for simde__m128i

### DIFF
--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -244,9 +244,9 @@ typedef union {
   typedef __m128i simde__m128i;
   typedef __m128d simde__m128d;
 #elif defined(SIMDE_SSE2_NEON)
-  typedef __attribute__((neon_vector_type(2))) int64_t simde__m128i;
+   typedef int64x2_t simde__m128i;
 #  if defined(SIMDE_ARCH_AARCH64)
-     typedef __attribute__((neon_vector_type(2))) double simde__m128d;
+     typedef float64x2_t simde__m128d;
 #  elif defined(SIMDE_VECTOR_SUBSCRIPT)
      typedef simde_float64 simde__m128d SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
 #  else

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -244,9 +244,9 @@ typedef union {
   typedef __m128i simde__m128i;
   typedef __m128d simde__m128d;
 #elif defined(SIMDE_SSE2_NEON)
-   typedef float32x4_t simde__m128i;
+  typedef __attribute__((neon_vector_type(2))) int64_t simde__m128i;
 #  if defined(SIMDE_ARCH_AARCH64)
-     typedef float64x2_t simde__m128d;
+     typedef __attribute__((neon_vector_type(2))) double simde__m128d;
 #  elif defined(SIMDE_VECTOR_SUBSCRIPT)
      typedef simde_float64 simde__m128d SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
 #  else


### PR DESCRIPTION
Previously typeof(m128) == typeof(m128i) and this is a problem for code that use mmx types to specialize templates. Specifically the following compiles for Intel, but fails for Arm:
template<>
inline void Foo<__m128>::Bar()
{ . . .}
template<>
inline void Foo<__m128i>::Bar()	<— fails because the underlying type float32x4_t has already been specialized.
{ . . .}

The Intel defines are:
	typedef float __m128 __attribute__((__vector_size__(16), __aligned__(16)));
	typedef long long __m128i __attribute__((__vector_size__(16), __aligned__(16)));

This proposal switches __m128i to using int64_t