### PR TITLE
suggestion: drone: add Fedora rawhide clang build.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   - CFLAGS="$ARCH_FLAGS" CXXFLAGS="$ARCH_FLAGS" meson ..
   - ninja -v
   - ./test/run-tests
-  
+
 ---
 kind: pipeline
 type: docker
@@ -236,3 +236,33 @@ steps:
 #   - CFLAGS="$ARCH_FLAGS" CXXFLAGS="$ARCH_FLAGS" meson ..
 #   - ninja -v
 #   - ./test/run-tests
+
+---
+kind: pipeline
+type: docker
+name: "fedora clang arm64 flags"
+platform:
+  os: linux
+  arch: arm64
+steps:
+- name: test
+  image: fedora:rawhide
+  environment:
+    CC: clang
+    CXX: clang++
+  commands:
+  - uname -m
+  - cat /proc/cpuinfo
+  - dnf install -y clang ninja-build git-core python3-pip
+  - pip3 install meson
+  - git submodule update --init --recursive
+  - mkdir -p build
+  - cd build
+  # optflags RPM macro works with gcc.
+  # Some flags and specs are not available with clang.
+  # https://lists.fedoraproject.org/archives/list/packaging@lists.fedoraproject.org/message/W5UFLUADNB4VF3OBUBSNAPOQL6XBCP74/
+  - ARCH_FLAGS=$(rpm -E "%{optflags}" | sed -e 's| -fstack-clash-protection||' -e 's| -specs=[^ ]*||g')
+  - CFLAGS="$ARCH_FLAGS" CXXFLAGS="$ARCH_FLAGS" meson ..
+  - ninja -v
+  - ./test/run-tests
+  failure: ignore


### PR DESCRIPTION
This PR is to add Fedora rawhide aarch64 (arm64) clang (10.0.0) case to Drone CI.
As the rawhide is a development environment, while it's good to check it on the latest compilers, it might be good to build with `failure: ignore`.

And it reproduces https://github.com/nemequ/simde/issues/167 .
