### PR TITLE
Native alias test

### DIFF
--- a/native-calls.c
+++ b/native-calls.c
@@ -1,0 +1,6 @@
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include "simde/x86/sse2.h"
+
+# _mm_stream_si64(__int64* mem_addr, __int64 a)
+
+# _mm_maskmove_si64(__m64 a, __m64 mask, char* mem_addr)

--- a/native-calls.c
+++ b/native-calls.c
@@ -1,6 +1,0 @@
-#define SIMDE_ENABLE_NATIVE_ALIASES
-#include "simde/x86/sse2.h"
-
-# _mm_stream_si64(__int64* mem_addr, __int64 a)
-
-# _mm_maskmove_si64(__m64 a, __m64 mask, char* mem_addr)

--- a/simde/x86/avx.h
+++ b/simde/x86/avx.h
@@ -4315,7 +4315,7 @@ simde_mm256_setr_epi32 (
 
 SIMDE__FUNCTION_ATTRIBUTES
 simde__m256i
-simde_mm256_setr_epi64 (int64_t  e3, int64_t  e2, int64_t  e1, int64_t  e0) {
+simde_mm256_setr_epi64x (int64_t  e3, int64_t  e2, int64_t  e1, int64_t  e0) {
 #if defined(SIMDE_AVX_NATIVE)
   return _mm256_setr_epi64x(e3, e2, e1, e0);
 #else
@@ -4323,8 +4323,8 @@ simde_mm256_setr_epi64 (int64_t  e3, int64_t  e2, int64_t  e1, int64_t  e0) {
 #endif
 }
 #if defined(SIMDE_AVX_ENABLE_NATIVE_ALIASES)
-#  define _mm256_setr_epi64(e3, e2, e1, e0) \
-    simde_mm256_setr_epi64(e3, e2, e1, e0)
+#  define _mm256_setr_epi64x(e3, e2, e1, e0) \
+    simde_mm256_setr_epi64x(e3, e2, e1, e0)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES

--- a/simde/x86/avx.h
+++ b/simde/x86/avx.h
@@ -1490,7 +1490,7 @@ simde_mm256_broadcast_ps (simde__m128 const * mem_addr) {
 #endif
 }
 #if defined(SIMDE_AVX_ENABLE_NATIVE_ALIASES)
-#  define _mm256_broadcast_ps(mem_addr) simde_mm256_broadcast_ps(HEDLEY_REINTERPRET_CAST(float const*, mem_addr))
+#  define _mm256_broadcast_ps(mem_addr) simde_mm256_broadcast_ps(HEDLEY_REINTERPRET_CAST(simde__m128 const*, mem_addr))
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES

--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -1266,7 +1266,7 @@ simde_mm256_madd_epi16 (simde__m256i a, simde__m256i b) {
 #endif
 }
 #if defined(SIMDE_AVX2_ENABLE_NATIVE_ALIASES)
-#  define _mm256_add_epi16(a, b) simde_mm256_add_epi16(a, b)
+#  define _mm256_madd_epi16(a, b) simde_mm256_madd_epi16(a, b)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -2119,7 +2119,7 @@ simde_mm256_srli_si256 (simde__m256i a, const int imm8) {
        simde_mm_bsrli_si128(simde_mm256_extracti128_si256(a, 0), (imm8)))
 #endif
 #if defined(SIMDE_AVX2_ENABLE_NATIVE_ALIASES)
-#  define _mm256_srli_si256(a, imm8) simde_mm_srli_si256(a, imm8)
+#  define _mm256_srli_si256(a, imm8) simde_mm256_srli_si256(a, imm8)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES

--- a/simde/x86/avx512bw.h
+++ b/simde/x86/avx512bw.h
@@ -380,7 +380,7 @@ simde_mm512_cvtsepi16_epi8 (simde__m512i a) {
     return simde__m256i_from_private(r_);
   #endif
 }
-#if defined(SIMDE_AVX512VL_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_AVX512BW_ENABLE_NATIVE_ALIASES)
   #define _mm512_cvtsepi16_epi8(a) simde_mm512_cvtsepi16_epi8(a)
 #endif
 

--- a/simde/x86/avx512f.h
+++ b/simde/x86/avx512f.h
@@ -31,6 +31,9 @@
 HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 
+#  if defined(SIMDE_AVX512F_NATIVE)
+#    undef SIMDE_AVX512F_NATIVE
+#  endif
 #  if defined(SIMDE_ARCH_X86_AVX512F) && !defined(SIMDE_AVX512F_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
 #    define SIMDE_AVX512F_NATIVE
 #  elif defined(SIMDE_ARCH_ARM_NEON) && !defined(SIMDE_AVX512F_NO_NEON) && !defined(SIMDE_NO_NEON)
@@ -274,7 +277,7 @@ typedef union {
 #if !defined(SIMDE_AVX512F_NATIVE) && defined(SIMDE_ENABLE_NATIVE_ALIASES)
   #define SIMDE_AVX512F_ENABLE_NATIVE_ALIASES
   typedef simde__m512 __m512;
-  typedef simde__m512i __m512i;
+  //typedef simde__m512i __m512i;
   typedef simde__m512d __m512d;
 #endif
 

--- a/simde/x86/avx512f.h
+++ b/simde/x86/avx512f.h
@@ -3321,7 +3321,7 @@ simde_mm512_mask_test_epi32_mask (simde__mmask16 k1, simde__m512i a, simde__m512
   #endif
 }
 #if defined(SIMDE_AVX512F_ENABLE_NATIVE_ALIASES)
-  #define _mm512_mask_test_epi32_mask(a, b) simde_mm512_mask_test_epi32_mask(a, b)
+  #define _mm512_mask_test_epi32_mask(k1, a, b) simde_mm512_mask_test_epi32_mask(k1, a, b)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -3344,7 +3344,7 @@ simde_mm512_mask_test_epi64_mask (simde__mmask8 k1, simde__m512i a, simde__m512i
   #endif
 }
 #if defined(SIMDE_AVX512F_ENABLE_NATIVE_ALIASES)
-  #define _mm512_mask_test_epi64_mask(a, b) simde_mm512_mask_test_epi64_mask(a, b)
+  #define _mm512_mask_test_epi64_mask(k1, a, b) simde_mm512_mask_test_epi64_mask(k1, a, b)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES

--- a/simde/x86/fma.h
+++ b/simde/x86/fma.h
@@ -87,7 +87,7 @@ simde_mm256_fmadd_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fmadd_pd(a, b, c) simde_mm_fmadd_pd(a, b, c)
+#  define _mm256_fmadd_pd(a, b, c) simde_mm256_fmadd_pd(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -113,7 +113,7 @@ simde_mm256_fmadd_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fmadd_ps(a, b, c) simde_mm_fmadd_ps(a, b, c)
+#  define _mm256_fmadd_ps(a, b, c) simde_mm256_fmadd_ps(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -165,7 +165,7 @@ simde_mm256_fmaddsub_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fmaddsub_pd(a, b, c) simde_mm_fmaddsub_pd(a, b, c)
+#  define _mm256_fmaddsub_pd(a, b, c) simde_mm256_fmaddsub_pd(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -191,7 +191,7 @@ simde_mm256_fmaddsub_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fmaddsub_ps(a, b, c) simde_mm_fmaddsub_ps(a, b, c)
+#  define _mm256_fmaddsub_ps(a, b, c) simde_mm256_fmaddsub_ps(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -217,7 +217,7 @@ simde_mm256_fmsub_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fmsub_pd(a, b, c) simde_mm_fmsub_pd(a, b, c)
+#  define _mm256_fmsub_pd(a, b, c) simde_mm256_fmsub_pd(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -243,7 +243,7 @@ simde_mm256_fmsub_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fmsub_ps(a, b, c) simde_mm_fmsub_ps(a, b, c)
+#  define _mm256_fmsub_ps(a, b, c) simde_mm256_fmsub_ps(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -319,7 +319,7 @@ simde_mm256_fmsubadd_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fmsubadd_pd(a, b, c) simde_mm_fmsubadd_pd(a, b, c)
+#  define _mm256_fmsubadd_pd(a, b, c) simde_mm256_fmsubadd_pd(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -369,7 +369,7 @@ simde_mm256_fmsubadd_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fmsubadd_ps(a, b, c) simde_mm_fmsubadd_ps(a, b, c)
+#  define _mm256_fmsubadd_ps(a, b, c) simde_mm256_fmsubadd_ps(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -417,7 +417,7 @@ simde_mm256_fnmadd_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fnmadd_pd(a, b, c) simde_mm_fnmadd_pd(a, b, c)
+#  define _mm256_fnmadd_pd(a, b, c) simde_mm256_fnmadd_pd(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -465,7 +465,7 @@ simde_mm256_fnmadd_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fnmadd_ps(a, b, c) simde_mm_fnmadd_ps(a, b, c)
+#  define _mm256_fnmadd_ps(a, b, c) simde_mm256_fnmadd_ps(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -557,7 +557,7 @@ simde_mm256_fnmsub_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fnmsub_pd(a, b, c) simde_mm_fnmsub_pd(a, b, c)
+#  define _mm256_fnmsub_pd(a, b, c) simde_mm256_fnmsub_pd(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES
@@ -605,7 +605,7 @@ simde_mm256_fnmsub_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
 #endif
 }
 #if defined(SIMDE_FMA_ENABLE_NATIVE_ALIASES)
-#  define _mm_fnmsub_ps(a, b, c) simde_mm_fnmsub_ps(a, b, c)
+#  define _mm256_fnmsub_ps(a, b, c) simde_mm256_fnmsub_ps(a, b, c)
 #endif
 
 SIMDE__FUNCTION_ATTRIBUTES

--- a/test/x86/avx.c
+++ b/test/x86/avx.c
@@ -10318,7 +10318,7 @@ test_simde_mm256_setr_epi32(const MunitParameter params[], void* data) {
 }
 
 static MunitResult
-test_simde_mm256_setr_epi64(const MunitParameter params[], void* data) {
+test_simde_mm256_setr_epi64x(const MunitParameter params[], void* data) {
   (void) params;
   (void) data;
 
@@ -10361,7 +10361,7 @@ test_simde_mm256_setr_epi64(const MunitParameter params[], void* data) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
-    simde__m256i r = simde_mm256_setr_epi64(
+    simde__m256i r = simde_mm256_setr_epi64x(
         test_vec[i].a[ 0], test_vec[i].a[ 1], test_vec[i].a[ 2], test_vec[i].a[ 3]);
     simde_assert_m256i_i64(r, ==, test_vec[i].r);
   }
@@ -13669,7 +13669,7 @@ static MunitTest test_suite_tests[] = {
   SIMDE_TESTS_DEFINE_TEST(mm256_setr_epi8),
   SIMDE_TESTS_DEFINE_TEST(mm256_setr_epi16),
   SIMDE_TESTS_DEFINE_TEST(mm256_setr_epi32),
-  SIMDE_TESTS_DEFINE_TEST(mm256_setr_epi64),
+  SIMDE_TESTS_DEFINE_TEST(mm256_setr_epi64x),
   SIMDE_TESTS_DEFINE_TEST(mm256_setr_ps),
   SIMDE_TESTS_DEFINE_TEST(mm256_setr_pd),
   SIMDE_TESTS_DEFINE_TEST(mm256_setr_m128),

--- a/test/x86/sse.c
+++ b/test/x86/sse.c
@@ -3041,7 +3041,11 @@ test_simde_mm_maskmove_si64(const MunitParameter params[], void* data) {
     int8_t r[8];
     memcpy(r, test_vec[i].b, sizeof(r));
 
+#if defined SIMDE_SSE_NATIVE
+    simde_mm_maskmove_si64(test_vec[i].a, test_vec[i].mask, (char *)r);
+#else
     simde_mm_maskmove_si64(test_vec[i].a, test_vec[i].mask, r);
+#endif
     simde_assert_int8vx(8, r, ==, test_vec[i].r);
   }
 

--- a/test/x86/sse.c
+++ b/test/x86/sse.c
@@ -3041,7 +3041,7 @@ test_simde_mm_maskmove_si64(const MunitParameter params[], void* data) {
     int8_t r[8];
     memcpy(r, test_vec[i].b, sizeof(r));
 
-#if defined SIMDE_SSE_NATIVE
+#if defined SIMDE_SSE_NATIVE && defined SIMDE_NATIVE_ALIASES_TESTING
     simde_mm_maskmove_si64(test_vec[i].a, test_vec[i].mask, (char *)r);
 #else
     simde_mm_maskmove_si64(test_vec[i].a, test_vec[i].mask, r);

--- a/test/x86/sse2.c
+++ b/test/x86/sse2.c
@@ -4582,7 +4582,7 @@ test_simde_mm_maskmoveu_si128(const MunitParameter params[], void* data) {
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
     int8_t r[16];
     memcpy(r, test_vec[i].i, 16);
-#if defined SIMDE_SSE2_NATIVE
+#if defined SIMDE_SSE2_NATIVE && defined SIMDE_NATIVE_ALIASES_TESTING
     simde_mm_maskmoveu_si128(test_vec[i].a, test_vec[i].mask, (char *) r);
 #else
     simde_mm_maskmoveu_si128(test_vec[i].a, test_vec[i].mask, r);
@@ -7961,7 +7961,7 @@ test_simde_mm_stream_si64(const MunitParameter params[], void* data) {
 
   for (size_t i = 0 ; i < sizeof(test_vec) / sizeof(test_vec[0]) ; i++) {
     int64_t r;
-#if defined SIMDE_SSE2_NATIVE
+#if defined SIMDE_SSE2_NATIVE && defined SIMDE_NATIVE_ALIASES_TESTING
     simde_mm_stream_si64((long long int*)&r, test_vec[i].a);
 #else
     simde_mm_stream_si64(&r, test_vec[i].a);

--- a/test/x86/sse2.c
+++ b/test/x86/sse2.c
@@ -4582,7 +4582,11 @@ test_simde_mm_maskmoveu_si128(const MunitParameter params[], void* data) {
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
     int8_t r[16];
     memcpy(r, test_vec[i].i, 16);
+#if defined SIMDE_SSE2_NATIVE
+    simde_mm_maskmoveu_si128(test_vec[i].a, test_vec[i].mask, (char *) r);
+#else
     simde_mm_maskmoveu_si128(test_vec[i].a, test_vec[i].mask, r);
+#endif
     simde_assert_typev(int8_t, PRId8, 16, r, ==, test_vec[i].r);
   }
 
@@ -7957,7 +7961,11 @@ test_simde_mm_stream_si64(const MunitParameter params[], void* data) {
 
   for (size_t i = 0 ; i < sizeof(test_vec) / sizeof(test_vec[0]) ; i++) {
     int64_t r;
+#if defined SIMDE_SSE2_NATIVE
+    simde_mm_stream_si64((long long int*)&r, test_vec[i].a);
+#else
     simde_mm_stream_si64(&r, test_vec[i].a);
+#endif
     munit_assert_int64(r, ==, test_vec[i].r);
   }
 

--- a/test/x86/sse4.1.c
+++ b/test/x86/sse4.1.c
@@ -3075,7 +3075,11 @@ test_simde_mm_stream_load_si128(const MunitParameter params[], void* data) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+#if defined SIMDE_SSE4_1_NATIVE
+    simde__m128i r = simde_mm_stream_load_si128((__m128i*)&(test_vec[i].a));
+#else
     simde__m128i r = simde_mm_stream_load_si128(&(test_vec[i].a));
+#endif
     simde_assert_m128i_i32(r, ==, test_vec[i].r);
   }
 

--- a/test/x86/sse4.1.c
+++ b/test/x86/sse4.1.c
@@ -3075,7 +3075,7 @@ test_simde_mm_stream_load_si128(const MunitParameter params[], void* data) {
   };
 
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
-#if defined SIMDE_SSE4_1_NATIVE
+#if defined SIMDE_SSE4_1_NATIVE && defined SIMDE_NATIVE_ALIASES_TESTING
     simde__m128i r = simde_mm_stream_load_si128((__m128i*)&(test_vec[i].a));
 #else
     simde__m128i r = simde_mm_stream_load_si128(&(test_vec[i].a));


### PR DESCRIPTION
Script used for testing: https://gist.github.com/mr-c/90dbca3383037914dbdd5abf935231d9

The following functions are implemented inside GCC 10 but not GCC 9, which causes problems when using the NATIVE_ALIASES

```
_mm256_loadu2_m128
_mm256_loadu2_m128d
_mm256_loadu2_m128i
_mm256_storeu2_m128d
_mm256_storeu2_m128
_mm256_storeu2_m128i
_mm256_zextps128_ps256
_mm256_zextpd128_pd256
_mm256_zextsi128_si256
```

The following functions need to be manually unrolled, ideally (but are probably fine as is)

```
AVX2:
_mm256_extract_epi8
_mm256_extract_epi16
AVX:
_mm256_extract_epi32
_mm256_extract_epi64
_mm256_insert_epi8
_mm256_insert_epi16
_mm256_insert_epi32
_mm256_insert_epi64
```