### PR TITLE
drone: remove failure ignore on Fedora clang.

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -241,8 +241,7 @@ def get_jobs():
         "environment": {
           "CC": "clang",
           "CXX": "clang++",
-        },
-        "failure": "ignore"
+        }
       }
     ],
     "custom": {


### PR DESCRIPTION
I noticed Drone CI "fedora clang arm64 flags" build succeeds now by the fix https://github.com/nemequ/simde/issues/167 .
So, let's remove `"failure": "ignore"` on the build.
