### PR TITLE
altivec c++: un-redefine bool, pixel, and vector

### DIFF
--- a/simde/simde-features.h
+++ b/simde/simde-features.h
@@ -280,6 +280,13 @@
 #endif
 #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
   #include <altivec.h>
+  #if defined(SIMDE_ENABLE_NATIVE_ALIASES) && defined (__cplusplus)
+    #if defined(__VEC__) && defined(__ALTIVEC__) && !defined(__APPLE_ALTIVEC__)
+    #  undef vector
+    #  undef pixel
+    #  undef bool
+    #endif
+  #endif
 #endif
 
 #endif /* !defined(SIMDE_FEATURES_H) */


### PR DESCRIPTION
On ppc64el, altivec.h redefines bool, pixel and vector which can collide with
c++ types.
As altivec.h explains, it's possible to undefine those for C++ compatibility
which let it define the variables that other files will use while not impacting
SIMDe.

Co-authored-by: Frédéric Bonnard <frediz@debian.org>