### PR TITLE
ppc64le: add missing conversions to simde__m* return types

### DIFF
--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -2059,7 +2059,7 @@ simde_mm256_slli_epi16 (simde__m256i a, const int imm8)
          simde_mm_slli_epi16(simde_mm256_extracti128_si256(a, 0), (imm8)))
 #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
 #  define simde_mm256_slli_epi16(a, imm8) \
-     vec_sl(simde__m256i_to_private(a).i16, vec_splats(imm8))
+     simde__m256i_from_altivec_i16(vec_sl(simde__m256i_to_private(a).i16, vec_splats(imm8)))
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
   #undef _mm256_slli_epi16
@@ -2094,7 +2094,7 @@ simde_mm256_slli_epi32 (simde__m256i a, const int imm8)
          simde_mm_slli_epi32(simde_mm256_extracti128_si256(a, 0), (imm8)))
 #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
 #  define simde_mm256_slli_epi32(a, imm8) \
-     vec_sl(simde__m256i_to_private(a).i32, vec_splats(imm8))
+     simde__m256i_from_altivec_i32(vec_sl(simde__m256i_to_private(a).i32, vec_splats(imm8)))
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
   #undef _mm256_slli_epi32
@@ -2340,7 +2340,7 @@ simde_mm256_srli_epi16 (simde__m256i a, const int imm8) {
          simde_mm_srli_epi16(simde_mm256_extracti128_si256(a, 0), (imm8)))
 #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
 #  define simde_mm256_srli_epi16(a, imm8) \
-     vec_sr(simde__m256i_to_private(a).i16, vec_splats(imm8))
+     simde__m256i_from_altivec_i16(vec_sr(simde__m256i_to_private(a).i16, vec_splats(imm8)))
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
   #undef _mm256_srli_epi16
@@ -2374,7 +2374,7 @@ simde_mm256_srli_epi32 (simde__m256i a, const int imm8) {
          simde_mm_srli_epi32(simde_mm256_extracti128_si256(a, 0), (imm8)))
 #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
 #  define simde_mm256_srli_epi32(a, imm8) \
-     vec_sr(simde__m256i_to_private(a).i32, vec_splats(imm8))
+     simde__m256i_from_altivec_i32(vec_sr(simde__m256i_to_private(a).i32, vec_splats(imm8)))
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
   #undef _mm256_srli_epi32

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -911,7 +911,7 @@ simde_mm_bslli_si128 (simde__m128i a, const int imm8)
   simde__m128i_from_neon_i8(((imm8) <= 0) ? simde__m128i_to_neon_i8(a) : (((imm8) > 15) ? (vdupq_n_s8(0)) : (vextq_s8(vdupq_n_s8(0), simde__m128i_to_neon_i8(a), 16 - (imm8)))))
 #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
 #  define simde_mm_bslli_si128(a, imm8) \
-  vec_slo(simde__m128i_to_private(a).altivec_u8, vec_splats((char)(imm8 << 3)))
+  simde__m128i_from_alitvec_u8(vec_slo(simde__m128i_to_private(a).altivec_u8, vec_splats((char)(imm8 << 3))))
 #endif
 #define simde_mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
@@ -966,7 +966,7 @@ simde_mm_bsrli_si128 (simde__m128i a, const int imm8)
   simde__m128i_from_neon_i8(((imm8) & ~15) ? vdupq_n_s8(0) : vextq_s8(simde__m128i_to_private(a).neon_i8, vdupq_n_s8(0), SIMDE_MASK_NZ_(imm8, 15)))
 #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
 #  define simde_mm_bsrli_si128(a, imm8) \
-  vec_sro(simde__m128i_to_private(a).altivec_u8, vec_splats((char)(imm8 << 3)))
+  simde__m128i_from_altivec_u8(vec_sro(simde__m128i_to_private(a).altivec_u8, vec_splats((char)(imm8 << 3))))
 #endif
 #define simde_mm_srli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)

--- a/test/docker/Dockerfile.ppc64el
+++ b/test/docker/Dockerfile.ppc64el
@@ -1,9 +1,26 @@
 FROM debian:bullseye-slim
-RUN apt-get update && apt-get install -y gcc-9-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu qemu-user-static cmake binfmt-support
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  binfmt-support \
+  ca-certificates \
+  cmake \
+  curl \
+  binutils \
+  gcc-9-powerpc64le-linux-gnu \
+  g++-powerpc64le-linux-gnu \
+  libxml2-utils \
+  make \
+  qemu-user-static
 COPY . /simde
 WORKDIR /simde
-RUN mkdir -p test/build_s390x
-WORKDIR /simde/test/build_s390x
-RUN CC=/usr/bin/powerpc64le-linux-gnu-gcc-9 CXX=/usr/bin/powerpc64le-linux-gnu-g++-9 cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -mcpu=power8" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -mcpu=power8" ../ && \
+# RUN mkdir -p test/build_ppc64le
+# WORKDIR /simde/test/build_ppc64le
+# RUN CC=/usr/bin/powerpc64le-linux-gnu-gcc-9 CXX=/usr/bin/powerpc64le-linux-gnu-g++-9 cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -mcpu=power8" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -mcpu=power8" ../ && \
+#   make -j$(nproc)
+# RUN QEMU_LD_PREFIX=/usr/powerpc64le-linux-gnu/ /usr/bin/qemu-ppc64le-static ./run-tests
+WORKDIR /simde
+RUN ./test/native-aliases.sh
+RUN mkdir -p test/build_ppc64le_native
+WORKDIR /simde/test/build_ppc64le_native
+RUN CC=/usr/bin/powerpc64le-linux-gnu-gcc-9 CXX=/usr/bin/powerpc64le-linux-gnu-g++-9 cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -mcpu=power8 -DSIMDE_ENABLE_NATIVE_ALIASES -DSIMDE_NATIVE_ALIASES_TESTING" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -mcpu=power8 -DSIMDE_ENABLE_NATIVE_ALIASES -DSIMDE_NATIVE_ALIASES_TESTING" ../ && \
   make -j$(nproc)
 RUN QEMU_LD_PREFIX=/usr/powerpc64le-linux-gnu/ /usr/bin/qemu-ppc64le-static ./run-tests

--- a/test/native-aliases.sh
+++ b/test/native-aliases.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Convert SIMDe test cases to strip the simde_ prefix to test native
 # aliases.


### PR DESCRIPTION
I had to make a pull request because `remote: error: Required status check "nemequ.simde" is expected.`