### PR TITLE
avx512f: Add missing and retouch existing movm and mask{,z}_mov functions

### DIFF
--- a/simde/x86/avx512f.h
+++ b/simde/x86/avx512f.h
@@ -926,8 +926,8 @@ simde_mm512_movm_epi32 (simde__mmask16 k) {
     simde__m512i_private r_;
 
     #if defined(SIMDE_X86_SSE2_NATIVE)
-      r_.m256i[0] = simde_mm256_movm_epi32(k     );
-      r_.m256i[1] = simde_mm256_movm_epi32(k >> 8);
+    r_.m256i[0] = simde_mm256_movm_epi32(HEDLEY_STATIC_CAST(simde__mmask8, k     ));
+    r_.m256i[1] = simde_mm256_movm_epi32(HEDLEY_STATIC_CAST(simde__mmask8, k >> 8));
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {

--- a/simde/x86/avx512f.h
+++ b/simde/x86/avx512f.h
@@ -373,1117 +373,6 @@ simde__m512d_to_private(simde__m512d v) {
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_movm_epi8 (simde__mmask16 k) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm_movm_epi8(k);
-  #elif defined(SIMDE_X86_SSSE3_NATIVE)
-    const simde__m128i zero = simde_mm_setzero_si128();
-    const simde__m128i bits = simde_mm_set_epi16(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80);
-    const simde__m128i shuffle = simde_mm_set_epi8(15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 0);
-    simde__m128i r;
-
-    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
-    r = simde_mm_mullo_epi16(r, bits);
-    r = simde_mm_shuffle_epi8(r, shuffle);
-    r = simde_mm_cmpgt_epi8(zero, r);
-
-    return r;
-  #else
-    simde__m128i_private r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-      r_.i8[i] = ((k >> i) & 1) ? ~INT8_C(0) : INT8_C(0);
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm_movm_epi8
-  #define _mm_movm_epi8(k) simde_mm_movm_epi8(k)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_movm_epi8 (simde__mmask32 k) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_movm_epi8(k);
-  #elif defined(SIMDE_X86_AVX2_NATIVE)
-    const simde__m256i zero = simde_mm256_setzero_si256();
-    const simde__m256i bits = simde_mm256_broadcastsi128_si256(simde_mm_set_epi16(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80));
-    const simde__m256i shuffle = simde_mm256_broadcastsi128_si256(simde_mm_set_epi8(15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 0));
-    simde__m256i r;
-
-    r = simde_mm256_set_m128i(simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k >> 16)), simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k)));
-    r = simde_mm256_mullo_epi16(r, bits);
-    r = simde_mm256_shuffle_epi8(r, shuffle);
-    r = simde_mm256_cmpgt_epi8(zero, r);
-
-    return r;
-  #else
-    simde__m256i_private r_;
-
-    #if defined(SIMDE_X86_SSSE3_NATIVE)
-      r_.m128i[0] = simde_mm_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k));
-      r_.m128i[1] = simde_mm_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k >> 16));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = ((k >> i) & 1) ? ~INT8_C(0) : INT8_C(0);
-      }
-    #endif
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_movm_epi8
-  #define _mm256_movm_epi8(k) simde_mm256_movm_epi8(k)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512i
-simde_mm512_movm_epi8 (simde__mmask64 k) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm512_movm_epi8(k);
-  #else
-    simde__m512i_private r_;
-
-    #if defined(SIMDE_X86_SSSE3_NATIVE)
-      r_.m256i[0] = simde_mm256_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k));
-      r_.m256i[1] = simde_mm256_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k >> 32));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = ((k >> i) & 1) ? ~INT8_C(0) : INT8_C(0);
-      }
-    #endif
-
-    return simde__m512i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_movm_epi8
-  #define _mm512_movm_epi8(k) simde_mm512_movm_epi8(k)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_movm_epi16 (simde__mmask8 k) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm_movm_epi16(k);
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
-    const simde__m128i bits = simde_mm_set_epi16(0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000, INT16_MIN /* 0x8000 */);
-    simde__m128i r;
-
-    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
-    r = simde_mm_mullo_epi16(r, bits);
-    r = simde_mm_srai_epi16(r, 15);
-
-    return r;
-  #else
-    simde__m128i_private r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-      r_.i16[i] = ((k >> i) & 1) ? ~INT16_C(0) : INT16_C(0);
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm_movm_epi16
-  #define _mm_movm_epi16(k) simde_mm_movm_epi16(k)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_movm_epi16 (simde__mmask16 k) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_movm_epi16(k);
-  #elif defined(SIMDE_X86_AVX2_NATIVE)
-    const simde__m256i bits = simde_mm256_set_epi16(0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080,
-                                                    0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000, INT16_MIN /* 0x8000 */);
-    simde__m256i r;
-
-    r = simde_mm256_set1_epi16(HEDLEY_STATIC_CAST(short, k));
-    r = simde_mm256_mullo_epi16(r, bits);
-    r = simde_mm256_srai_epi16(r, 15);
-
-    return r;
-  #else
-    simde__m256i_private r_;
-
-    #if defined(SIMDE_X86_SSE2_NATIVE)
-      r_.m128i[0] = simde_mm_movm_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k));
-      r_.m128i[1] = simde_mm_movm_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k >> 8));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = ((k >> i) & 1) ? ~INT16_C(0) : INT16_C(0);
-      }
-    #endif
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_movm_epi16
-  #define _mm256_movm_epi16(k) simde_mm256_movm_epi16(k)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_movm_epi32 (simde__mmask8 k) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm_movm_epi32(k);
-  #elif defined(SIMDE_X86_AVX2_NATIVE)
-    const simde__m128i shifts = simde_mm_set_epi32(28, 29, 30, 31);
-    simde__m128i r;
-
-    r = simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int, k));
-    r = simde_mm_sllv_epi32(r, shifts);
-    r = simde_mm_srai_epi32(r, 31);
-
-    return r;
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
-    const simde__m128i bits = simde_mm_set_epi32(0x10000000, 0x20000000, 0x40000000, INT32_MIN /* 0x80000000 */);
-    simde__m128i r;
-
-    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
-    r = simde_mm_mullo_epi16(r, bits);
-    r = simde_mm_srai_epi32(r, 31);
-
-    return r;
-  #else
-    simde__m128i_private r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-      r_.i32[i] = ((k >> i) & 1) ? ~INT32_C(0) : INT32_C(0);
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm_movm_epi32
-  #define _mm_movm_epi32(k) simde_mm_movm_epi32(k)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_movm_epi32 (simde__mmask8 k) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_movm_epi32(k);
-  #elif defined(SIMDE_X86_AVX2_NATIVE)
-    const simde__m256i shifts = simde_mm256_set_epi32(24, 25, 26, 27, 28, 29, 30, 31);
-    simde__m256i r;
-
-    r = simde_mm256_set1_epi32(HEDLEY_STATIC_CAST(int, k));
-    r = simde_mm256_sllv_epi32(r, shifts);
-    r = simde_mm256_srai_epi32(r, 31);
-
-    return r;
-  #else
-    simde__m256i_private r_;
-
-    #if defined(SIMDE_X86_SSE2_NATIVE)
-      r_.m128i[0] = simde_mm_movm_epi32(k     );
-      r_.m128i[1] = simde_mm_movm_epi32(k >> 4);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = ((k >> i) & 1) ? ~INT32_C(0) : INT32_C(0);
-      }
-    #endif
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_movm_epi32
-  #define _mm256_movm_epi32(k) simde_mm256_movm_epi32(k)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_mask_mov_epi8(simde__m128i src, simde__mmask16 k, simde__m128i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm_mask_mov_epi8(src, k, a);
-  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
-    return simde_mm_blendv_epi8(src, a, simde_mm_movm_epi8(k));
-  #elif defined(SIMDE_X86_SSSE3_NATIVE)
-    simde__m128i mask = simde_mm_movm_epi8(k);
-    return simde_mm_or_si128(simde_mm_and_si128(mask, a), simde_mm_andnot_si128(mask, src));
-  #else
-    simde__m128i_private
-      src_ = simde__m128i_to_private(src),
-      a_ = simde__m128i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-      r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : src_.i8[i];
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm_mask_mov_epi8
-  #define _mm_mask_mov_epi8(src, k, a) simde_mm_mask_mov_epi8(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_mask_mov_epi16(simde__m128i src, simde__mmask8 k, simde__m128i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm_mask_mov_epi16(src, k, a);
-  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
-    return simde_mm_blendv_epi8(src, a, simde_mm_movm_epi16(k));
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
-    simde__m128i mask = simde_mm_movm_epi16(k);
-    return simde_mm_or_si128(simde_mm_and_si128(mask, a), simde_mm_andnot_si128(mask, src));
-  #else
-    simde__m128i_private
-      src_ = simde__m128i_to_private(src),
-      a_ = simde__m128i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-      r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : src_.i16[i];
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm_mask_mov_epi16
-  #define _mm_mask_mov_epi16(src, k, a) simde_mm_mask_mov_epi16(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_mask_mov_epi32(simde__m128i src, simde__mmask8 k, simde__m128i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm_mask_mov_epi32(src, k, a);
-  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
-    return simde_mm_blendv_epi8(src, a, simde_mm_movm_epi32(k));
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
-    simde__m128i mask = simde_mm_movm_epi32(k);
-    return simde_mm_or_si128(simde_mm_and_si128(mask, a), simde_mm_andnot_si128(mask, src));
-  #else
-    simde__m128i_private
-      src_ = simde__m128i_to_private(src),
-      a_ = simde__m128i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-      r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : src_.i32[i];
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm_mask_mov_epi32
-  #define _mm_mask_mov_epi32(src, k, a) simde_mm_mask_mov_epi32(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_mask_mov_epi64(simde__m128i src, simde__mmask8 k, simde__m128i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm_mask_mov_epi64(src, k, a);
-  #else
-    simde__m128i_private
-      src_ = simde__m128i_to_private(src),
-      a_ = simde__m128i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-      r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : src_.i64[i];
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm_mask_mov_epi64
-  #define _mm_mask_mov_epi64(src, k, a) simde_mm_mask_mov_epi64(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_mask_mov_epi8 (simde__m256i src, simde__mmask32 k, simde__m256i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm256_mask_mov_epi8(src, k, a);
-  #elif defined(SIMDE_X86_AVX2_NATIVE)
-    return simde_mm256_blendv_epi8(src, a, simde_mm256_movm_epi8(k));
-  #else
-    simde__m256i_private
-      r_,
-      src_ = simde__m256i_to_private(src),
-      a_ = simde__m256i_to_private(a);
-
-    #if defined(SIMDE_X86_SSSE3_NATIVE)
-      r_.m128i[0] = simde_mm_mask_mov_epi8(src_.m128i[0], HEDLEY_STATIC_CAST(simde__mmask16, k      ), a_.m128i[0]);
-      r_.m128i[1] = simde_mm_mask_mov_epi8(src_.m128i[1], HEDLEY_STATIC_CAST(simde__mmask16, k >> 16), a_.m128i[1]);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : src_.i8[i];
-      }
-    #endif
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_mask_mov_epi8
-  #define _mm256_mask_mov_epi8(src, k, a) simde_mm256_mask_mov_epi8(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_mask_mov_epi16(simde__m256i src, simde__mmask16 k, simde__m256i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm256_mask_mov_epi16(src, k, a);
-  #elif defined(SIMDE_X86_AVX2_NATIVE)
-    return simde_mm256_blendv_epi8(src, a, simde_mm256_movm_epi16(k));
-  #else
-    simde__m256i_private
-      src_ = simde__m256i_to_private(src),
-      a_ = simde__m256i_to_private(a),
-      r_;
-
-    #if defined(SIMDE_X86_SSE2_NATIVE)
-      r_.m128i[0] = simde_mm_mask_mov_epi16(src_.m128i[0], HEDLEY_STATIC_CAST(simde__mmask8, k     ), a_.m128i[0]);
-      r_.m128i[1] = simde_mm_mask_mov_epi16(src_.m128i[1], HEDLEY_STATIC_CAST(simde__mmask8, k >> 8), a_.m128i[1]);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : src_.i16[i];
-      }
-    #endif
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_mask_mov_epi16
-  #define _mm256_mask_mov_epi16(src, k, a) simde_mm256_mask_mov_epi16(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_mask_mov_epi32(simde__m256i src, simde__mmask8 k, simde__m256i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_mask_mov_epi32(src, k, a);
-  #elif defined(SIMDE_X86_AVX2_NATIVE)
-    return simde_mm256_blendv_epi8(src, a, simde_mm256_movm_epi32(k));
-  #else
-    simde__m256i_private
-      src_ = simde__m256i_to_private(src),
-      a_ = simde__m256i_to_private(a),
-      r_;
-
-    #if defined(SIMDE_X86_SSE2_NATIVE)
-      r_.m128i[0] = simde_mm_mask_mov_epi32(src_.m128i[0], k     , a_.m128i[0]);
-      r_.m128i[1] = simde_mm_mask_mov_epi32(src_.m128i[1], k >> 4, a_.m128i[1]);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : src_.i32[i];
-      }
-    #endif
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_mask_mov_epi32
-  #define _mm256_mask_mov_epi32(src, k, a) simde_mm256_mask_mov_epi32(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_mask_mov_epi64(simde__m256i src, simde__mmask8 k, simde__m256i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_mask_mov_epi64(src, k, a);
-  #else
-    simde__m256i_private
-      src_ = simde__m256i_to_private(src),
-      a_ = simde__m256i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-      r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : src_.i64[i];
-    }
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_mask_mov_epi64
-  #define _mm256_mask_mov_epi64(src, k, a) simde_mm256_mask_mov_epi64(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256d
-simde_mm256_mask_mov_pd(simde__m256d src, simde__mmask8 k, simde__m256d a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_mask_mov_pd(src, k, a);
-  #else
-    return simde_mm256_castsi256_pd(simde_mm256_mask_mov_epi64(simde_mm256_castpd_si256(src), k, simde_mm256_castpd_si256(a)));
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_mask_mov_pd
-  #define _mm256_mask_mov_pd(src, k, a) simde_mm256_mask_mov_pd(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256
-simde_mm256_mask_mov_ps(simde__m256 src, simde__mmask8 k, simde__m256 a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_mask_mov_ps(src, k, a);
-  #else
-    return simde_mm256_castsi256_ps(simde_mm256_mask_mov_epi32(simde_mm256_castps_si256(src), k, simde_mm256_castps_si256(a)));
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_mask_mov_ps
-  #define _mm256_mask_mov_ps(src, k, a) simde_mm256_mask_mov_ps(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512i
-simde_mm512_mask_mov_epi8(simde__m512i src, simde__mmask64 k, simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm512_mask_mov_epi8(src, k, a);
-  #else
-    simde__m512i_private
-      src_ = simde__m512i_to_private(src),
-      a_ = simde__m512i_to_private(a),
-      r_;
-
-    r_.m256i[0] = simde_mm256_mask_mov_epi8(src_.m256i[0], HEDLEY_STATIC_CAST(simde__mmask32, k      ), a_.m256i[0]);
-    r_.m256i[1] = simde_mm256_mask_mov_epi8(src_.m256i[1], HEDLEY_STATIC_CAST(simde__mmask32, k >> 32), a_.m256i[1]);
-
-    return simde__m512i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_mask_mov_epi8
-  #define _mm512_mask_mov_epi8(src, k, a) simde_mm512_mask_mov_epi8(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512i
-simde_mm512_mask_mov_epi16(simde__m512i src, simde__mmask32 k, simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm512_mask_mov_epi16(src, k, a);
-  #else
-    simde__m512i_private
-      src_ = simde__m512i_to_private(src),
-      a_ = simde__m512i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-      r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : src_.i16[i];
-    }
-
-    return simde__m512i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_mask_mov_epi16
-  #define _mm512_mask_mov_epi16(src, k, a) simde_mm512_mask_mov_epi16(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512i
-simde_mm512_mask_mov_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512F_NATIVE)
-    return _mm512_mask_mov_epi32(src, k, a);
-  #else
-    simde__m512i_private
-      src_ = simde__m512i_to_private(src),
-      a_ = simde__m512i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-      r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : src_.i32[i];
-    }
-
-    return simde__m512i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_mask_mov_epi32
-  #define _mm512_mask_mov_epi32(src, k, a) simde_mm512_mask_mov_epi32(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512i
-simde_mm512_mask_mov_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512F_NATIVE)
-    return _mm512_mask_mov_epi64(src, k, a);
-  #else
-    simde__m512i_private
-      src_ = simde__m512i_to_private(src),
-      a_ = simde__m512i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-      r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : src_.i64[i];
-    }
-
-    return simde__m512i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_mask_mov_epi64
-  #define _mm512_mask_mov_epi64(src, k, a) simde_mm512_mask_mov_epi64(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512d
-simde_mm512_mask_mov_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
-  #if defined(SIMDE_X86_AVX512F_NATIVE)
-    return _mm512_mask_mov_pd(src, k, a);
-  #else
-    simde__m512d_private
-      src_ = simde__m512d_to_private(src),
-      a_ = simde__m512d_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-      r_.f64[i] = ((k >> i) & 1) ? a_.f64[i] : src_.f64[i];
-    }
-
-    return simde__m512d_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_mask_mov_pd
-  #define _mm512_mask_mov_pd(src, k, a) simde_mm512_mask_mov_pd(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512
-simde_mm512_mask_mov_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
-  #if defined(SIMDE_X86_AVX512F_NATIVE)
-    return _mm512_mask_mov_ps(src, k, a);
-  #else
-    simde__m512_private
-      src_ = simde__m512_to_private(src),
-      a_ = simde__m512_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
-      r_.f32[i] = ((k >> i) & 1) ? a_.f32[i] : src_.f32[i];
-    }
-
-    return simde__m512_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_mask_mov_ps
-  #define _mm512_mask_mov_ps(src, k, a) simde_mm512_mask_mov_ps(src, k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_maskz_mov_epi8(simde__mmask16 k, simde__m128i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm_maskz_mov_epi8(k, a);
-  #elif defined(SIMDE_X86_SSSE3_NATIVE)
-    return simde_mm_and_si128(a, simde_mm_movm_epi8(k));
-  #else
-    simde__m128i_private
-      a_ = simde__m128i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-      r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : INT8_C(0);
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm_maskz_mov_epi8
-  #define _mm_maskz_mov_epi8(k, a) simde_mm_maskz_mov_epi8(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_maskz_mov_epi16(simde__mmask8 k, simde__m128i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm_maskz_mov_epi16(k, a);
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
-    return simde_mm_and_si128(a, simde_mm_movm_epi16(k));
-  #else
-    simde__m128i_private
-      a_ = simde__m128i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-      r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : INT16_C(0);
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm_maskz_mov_epi16
-  #define _mm_maskz_mov_epi16(k, a) simde_mm_maskz_mov_epi16(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_maskz_mov_epi32(simde__mmask8 k, simde__m128i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm_maskz_mov_epi32(k, a);
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
-    return simde_mm_and_si128(a, simde_mm_movm_epi32(k));
-  #else
-    simde__m128i_private
-      a_ = simde__m128i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-      r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : INT32_C(0);
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm_maskz_mov_epi32
-  #define _mm_maskz_mov_epi32(k, a) simde_mm_maskz_mov_epi32(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_maskz_mov_epi64(simde__mmask8 k, simde__m128i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm_maskz_mov_epi64(k, a);
-  #else
-    simde__m128i_private
-      a_ = simde__m128i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-      r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : INT64_C(0);
-    }
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm_maskz_mov_epi64
-  #define _mm_maskz_mov_epi64(k, a) simde_mm_maskz_mov_epi64(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_maskz_mov_epi8 (simde__mmask32 k, simde__m256i a) {
-  #if defined(SIMDE_X86_AVX2_NATIVE)
-    return simde_mm256_and_si256(a, simde_mm256_movm_epi8(k));
-  #else
-    simde__m256i_private
-      a_ = simde__m256i_to_private(a),
-      r_;
-
-    #if defined(SIMDE_X86_SSSE3_NATIVE)
-      r_.m128i[0] = simde_mm_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k      ), a_.m128i[0]);
-      r_.m128i[1] = simde_mm_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k >> 16), a_.m128i[1]);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : INT8_C(0);
-      }
-    #endif
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
-  #define simde_mm256_maskz_mov_epi8(k, a) _mm256_maskz_mov_epi8(k, a)
-#endif
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_maskz_mov_epi8
-  #define _mm256_maskz_mov_epi8(k, a) simde_mm256_maskz_mov_epi8(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_maskz_mov_epi16(simde__mmask16 k, simde__m256i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm256_maskz_mov_epi16(k, a);
-  #elif defined(SIMDE_X86_AVX2_NATIVE)
-    return simde_mm256_and_si256(a, simde_mm256_movm_epi16(k));
-  #else
-    simde__m256i_private
-      a_ = simde__m256i_to_private(a),
-      r_;
-
-    #if defined(SIMDE_X86_SSE2_NATIVE)
-      r_.m128i[0] = simde_mm_maskz_mov_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k     ), a_.m128i[0]);
-      r_.m128i[1] = simde_mm_maskz_mov_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k >> 8), a_.m128i[1]);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : INT16_C(0);
-      }
-    #endif
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_maskz_mov_epi16
-  #define _mm256_maskz_mov_epi16(k, a) simde_mm256_maskz_mov_epi16(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_maskz_mov_epi32(simde__mmask8 k, simde__m256i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_maskz_mov_epi32(k, a);
-  #elif defined(SIMDE_X86_AVX2_NATIVE)
-    return simde_mm256_and_si256(a, simde_mm256_movm_epi32(k));
-  #else
-    simde__m256i_private
-      a_ = simde__m256i_to_private(a),
-      r_;
-
-    #if defined(SIMDE_X86_SSE2_NATIVE)
-      r_.m128i[0] = simde_mm_maskz_mov_epi32(k     , a_.m128i[0]);
-      r_.m128i[1] = simde_mm_maskz_mov_epi32(k >> 4, a_.m128i[1]);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : INT32_C(0);
-      }
-    #endif
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_maskz_mov_epi32
-  #define _mm256_maskz_mov_epi32(k, a) simde_mm256_maskz_mov_epi32(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256i
-simde_mm256_maskz_mov_epi64(simde__mmask8 k, simde__m256i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_maskz_mov_epi64(k, a);
-  #else
-    simde__m256i_private
-      a_ = simde__m256i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-      r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : INT64_C(0);
-    }
-
-    return simde__m256i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_maskz_mov_epi64
-  #define _mm256_maskz_mov_epi64(k, a) simde_mm256_maskz_mov_epi64(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256d
-simde_mm256_maskz_mov_pd(simde__mmask8 k, simde__m256d a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_maskz_mov_pd(k, a);
-  #else
-    return simde_mm256_castsi256_pd(simde_mm256_maskz_mov_epi64(k, simde_mm256_castpd_si256(a)));
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_maskz_mov_pd
-  #define _mm256_maskz_mov_pd(k, a) simde_mm256_maskz_mov_pd(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m256
-simde_mm256_maskz_mov_ps(simde__mmask8 k, simde__m256 a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm256_maskz_mov_ps(k, a);
-  #else
-    return simde_mm256_castsi256_ps(simde_mm256_maskz_mov_epi32(k, simde_mm256_castps_si256(a)));
-  #endif
-}
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
-  #undef _mm256_maskz_mov_ps
-  #define _mm256_maskz_mov_ps(k, a) simde_mm256_maskz_mov_ps(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512i
-simde_mm512_maskz_mov_epi8(simde__mmask64 k, simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm512_maskz_mov_epi8(k, a);
-  #else
-    simde__m512i_private
-      a_ = simde__m512i_to_private(a),
-      r_;
-
-    r_.m256i[0] = simde_mm256_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k      ), a_.m256i[0]);
-    r_.m256i[1] = simde_mm256_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k >> 32), a_.m256i[1]);
-
-    return simde__m512i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_maskz_mov_epi8
-  #define _mm512_maskz_mov_epi8(k, a) simde_mm512_maskz_mov_epi8(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512i
-simde_mm512_maskz_mov_epi16(simde__mmask32 k, simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm512_maskz_mov_epi16(k, a);
-  #else
-    simde__m512i_private
-      a_ = simde__m512i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-      r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : INT16_C(0);
-    }
-
-    return simde__m512i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_maskz_mov_epi16
-  #define _mm512_maskz_mov_epi16(k, a) simde_mm512_maskz_mov_epi16(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512i
-simde_mm512_maskz_mov_epi32(simde__mmask16 k, simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512F_NATIVE)
-    return _mm512_maskz_mov_epi32(k, a);
-  #else
-    simde__m512i_private
-      a_ = simde__m512i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-      r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : INT32_C(0);
-    }
-
-    return simde__m512i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_maskz_mov_epi32
-  #define _mm512_maskz_mov_epi32(k, a) simde_mm512_maskz_mov_epi32(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512i
-simde_mm512_maskz_mov_epi64(simde__mmask8 k, simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512F_NATIVE)
-    return _mm512_maskz_mov_epi64(k, a);
-  #else
-    simde__m512i_private
-      a_ = simde__m512i_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-      r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : INT64_C(0);
-    }
-
-    return simde__m512i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_maskz_mov_epi64
-  #define _mm512_maskz_mov_epi64(k, a) simde_mm512_maskz_mov_epi64(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512d
-simde_mm512_maskz_mov_pd(simde__mmask8 k, simde__m512d a) {
-  #if defined(SIMDE_X86_AVX512F_NATIVE)
-    return _mm512_maskz_mov_pd(k, a);
-  #else
-    simde__m512d_private
-      a_ = simde__m512d_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-      r_.f64[i] = ((k >> i) & 1) ? a_.f64[i] : SIMDE_FLOAT64_C(0.0);
-    }
-
-    return simde__m512d_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_maskz_mov_pd
-  #define _mm512_maskz_mov_pd(k, a) simde_mm512_maskz_mov_pd(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m512
-simde_mm512_maskz_mov_ps(simde__mmask16 k, simde__m512 a) {
-  #if defined(SIMDE_X86_AVX512F_NATIVE)
-    return _mm512_maskz_mov_ps(k, a);
-  #else
-    simde__m512_private
-      a_ = simde__m512_to_private(a),
-      r_;
-
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
-      r_.f32[i] = ((k >> i) & 1) ? a_.f32[i] : SIMDE_FLOAT32_C(0.0);
-    }
-
-    return simde__m512_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_maskz_mov_ps
-  #define _mm512_maskz_mov_ps(k, a) simde_mm512_maskz_mov_ps(k, a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__mmask64
-simde_mm512_movepi8_mask (simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm512_movepi8_mask(a);
-  #else
-    simde__m512i_private a_ = simde__m512i_to_private(a);
-    simde__mmask64 r;
-
-    #if defined(SIMDE_X86_AVX2_NATIVE)
-      r =             HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm256_movemask_epi8(a_.m256i[1])));
-      r = (r << 32) | HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm256_movemask_epi8(a_.m256i[0])));
-    #elif defined(SIMDE_X86_SSE2_NATIVE)
-      r =             HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm_movemask_epi8(a_.m128i[3])));
-      r = (r << 16) | HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm_movemask_epi8(a_.m128i[2])));
-      r = (r << 16) | HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm_movemask_epi8(a_.m128i[1])));
-      r = (r << 16) | HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm_movemask_epi8(a_.m128i[0])));
-    #else
-      r = 0;
-
-      SIMDE_VECTORIZE_REDUCTION(|:r)
-      for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++) {
-        r |= (a_.i8[i] < 0) ? (UINT64_C(1) << i) : 0;
-      }
-    #endif
-
-    return r;
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_movepi8_mask
-  #define _mm512_movepi8_mask(a) simde_mm512_movepi8_mask(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__mmask32
-simde_mm512_movepi16_mask (simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512BW_NATIVE)
-    return _mm512_movepi16_mask(a);
-  #else
-    simde__m512i_private a_ = simde__m512i_to_private(a);
-    simde__mmask32 r = 0;
-
-    SIMDE_VECTORIZE_REDUCTION(|:r)
-    for (size_t i = 0 ; i < (sizeof(a_.i16) / sizeof(a_.i16[0])) ; i++) {
-      r |= (a_.i16[i] < 0) ? (UINT32_C(1) << i) : 0;
-    }
-
-    return r;
-  #endif
-}
-#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_movepi16_mask
-  #define _mm512_movepi16_mask(a) simde_mm512_movepi16_mask(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__mmask16
-simde_mm512_movepi32_mask (simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
-    return _mm512_movepi32_mask(a);
-  #else
-    simde__m512i_private a_ = simde__m512i_to_private(a);
-    simde__mmask16 r = 0;
-
-    SIMDE_VECTORIZE_REDUCTION(|:r)
-    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
-      r |= (a_.i32[i] < 0) ? (UINT32_C(1) << i) : 0;
-    }
-
-    return r;
-  #endif
-}
-#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_movepi32_mask
-  #define _mm512_movepi32_mask(a) simde_mm512_movepi32_mask(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__mmask8
-simde_mm512_movepi64_mask (simde__m512i a) {
-  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
-    return _mm512_movepi64_mask(a);
-  #else
-    simde__m512i_private a_ = simde__m512i_to_private(a);
-    simde__mmask8 r = 0;
-
-    SIMDE_VECTORIZE_REDUCTION(|:r)
-    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
-      r |= (a_.i64[i] < 0) ? (UINT32_C(1) << i) : 0;
-    }
-
-    return r;
-  #endif
-}
-#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
-  #undef _mm512_movepi64_mask
-  #define _mm512_movepi64_mask(a) simde_mm512_movepi64_mask(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
 simde__m512
 simde_mm512_castpd_ps (simde__m512d a) {
   #if defined(SIMDE_X86_AVX512F_NATIVE)
@@ -1763,6 +652,1350 @@ simde_mm512_castsi512_si256 (simde__m512i a) {
 #if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
   #undef _mm512_castsi512_si256
   #define _mm512_castsi512_si256(a) simde_mm512_castsi512_si256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_movm_epi8 (simde__mmask16 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_movm_epi8(k);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    const simde__m128i zero = simde_mm_setzero_si128();
+    const simde__m128i bits = simde_mm_set_epi16(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80);
+    const simde__m128i shuffle = simde_mm_set_epi8(15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 0);
+    simde__m128i r;
+
+    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
+    r = simde_mm_mullo_epi16(r, bits);
+    r = simde_mm_shuffle_epi8(r, shuffle);
+    r = simde_mm_cmpgt_epi8(zero, r);
+
+    return r;
+  #else
+    simde__m128i_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = ((k >> i) & 1) ? ~INT8_C(0) : INT8_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_movm_epi8
+  #define _mm_movm_epi8(k) simde_mm_movm_epi8(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_movm_epi8 (simde__mmask32 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_movm_epi8(k);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const simde__m256i zero = simde_mm256_setzero_si256();
+    const simde__m256i bits = simde_mm256_broadcastsi128_si256(simde_mm_set_epi16(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80));
+    const simde__m256i shuffle = simde_mm256_broadcastsi128_si256(simde_mm_set_epi8(15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 0));
+    simde__m256i r;
+
+    r = simde_mm256_set_m128i(simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k >> 16)), simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k)));
+    r = simde_mm256_mullo_epi16(r, bits);
+    r = simde_mm256_shuffle_epi8(r, shuffle);
+    r = simde_mm256_cmpgt_epi8(zero, r);
+
+    return r;
+  #else
+    simde__m256i_private r_;
+
+    #if defined(SIMDE_X86_SSSE3_NATIVE)
+      r_.m128i[0] = simde_mm_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k));
+      r_.m128i[1] = simde_mm_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k >> 16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movm_epi8
+  #define _mm256_movm_epi8(k) simde_mm256_movm_epi8(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_movm_epi8 (simde__mmask64 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_movm_epi8(k);
+  #else
+    simde__m512i_private r_;
+
+    #if defined(SIMDE_X86_SSSE3_NATIVE)
+      r_.m256i[0] = simde_mm256_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k));
+      r_.m256i[1] = simde_mm256_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k >> 32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movm_epi8
+  #define _mm512_movm_epi8(k) simde_mm512_movm_epi8(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_movm_epi16 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_movm_epi16(k);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    const simde__m128i bits = simde_mm_set_epi16(0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000, INT16_MIN /* 0x8000 */);
+    simde__m128i r;
+
+    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
+    r = simde_mm_mullo_epi16(r, bits);
+    r = simde_mm_srai_epi16(r, 15);
+
+    return r;
+  #else
+    simde__m128i_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = ((k >> i) & 1) ? ~INT16_C(0) : INT16_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_movm_epi16
+  #define _mm_movm_epi16(k) simde_mm_movm_epi16(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_movm_epi16 (simde__mmask16 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_movm_epi16(k);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const simde__m256i bits = simde_mm256_set_epi16(0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080,
+                                                    0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000, INT16_MIN /* 0x8000 */);
+    simde__m256i r;
+
+    r = simde_mm256_set1_epi16(HEDLEY_STATIC_CAST(short, k));
+    r = simde_mm256_mullo_epi16(r, bits);
+    r = simde_mm256_srai_epi16(r, 15);
+
+    return r;
+  #else
+    simde__m256i_private r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_movm_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k));
+      r_.m128i[1] = simde_mm_movm_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k >> 8));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movm_epi16
+  #define _mm256_movm_epi16(k) simde_mm256_movm_epi16(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_movm_epi16 (simde__mmask32 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_movm_epi16(k);
+  #else
+    simde__m512i_private r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_movm_epi16(HEDLEY_STATIC_CAST(simde__mmask16, k));
+      r_.m256i[1] = simde_mm256_movm_epi16(HEDLEY_STATIC_CAST(simde__mmask16, k >> 16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movm_epi16
+  #define _mm512_movm_epi16(k) simde_mm512_movm_epi16(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_movm_epi32 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_movm_epi32(k);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const simde__m128i shifts = simde_mm_set_epi32(28, 29, 30, 31);
+    simde__m128i r;
+
+    r = simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int, k));
+    r = simde_mm_sllv_epi32(r, shifts);
+    r = simde_mm_srai_epi32(r, 31);
+
+    return r;
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    const simde__m128i bits = simde_mm_set_epi32(0x10000000, 0x20000000, 0x40000000, INT32_MIN /* 0x80000000 */);
+    simde__m128i r;
+
+    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
+    r = simde_mm_mullo_epi16(r, bits);
+    r = simde_mm_srai_epi32(r, 31);
+
+    return r;
+  #else
+    simde__m128i_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = ((k >> i) & 1) ? ~INT32_C(0) : INT32_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_movm_epi32
+  #define _mm_movm_epi32(k) simde_mm_movm_epi32(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_movm_epi32 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_movm_epi32(k);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const simde__m256i shifts = simde_mm256_set_epi32(24, 25, 26, 27, 28, 29, 30, 31);
+    simde__m256i r;
+
+    r = simde_mm256_set1_epi32(HEDLEY_STATIC_CAST(int, k));
+    r = simde_mm256_sllv_epi32(r, shifts);
+    r = simde_mm256_srai_epi32(r, 31);
+
+    return r;
+  #else
+    simde__m256i_private r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_movm_epi32(k     );
+      r_.m128i[1] = simde_mm_movm_epi32(k >> 4);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movm_epi32
+  #define _mm256_movm_epi32(k) simde_mm256_movm_epi32(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_movm_epi32 (simde__mmask16 k) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_movm_epi32(k);
+  #else
+    simde__m512i_private r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_movm_epi32(k     );
+      r_.m256i[1] = simde_mm256_movm_epi32(k >> 8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movm_epi32
+  #define _mm512_movm_epi32(k) simde_mm512_movm_epi32(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_movm_epi64 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_movm_epi64(k);
+    /* N.B. CM: These fallbacks may not be faster as there are only two elements */
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const simde__m128i shifts = simde_mm_set_epi32(30, 30, 31, 31);
+    simde__m128i r;
+
+    r = simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int, k));
+    r = simde_mm_sllv_epi32(r, shifts);
+    r = simde_mm_srai_epi32(r, 31);
+
+    return r;
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    const simde__m128i bits = simde_mm_set_epi32(0x40000000, 0x40000000, INT32_MIN /* 0x80000000 */, INT32_MIN /* 0x80000000 */);
+    simde__m128i r;
+
+    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
+    r = simde_mm_mullo_epi16(r, bits);
+    r = simde_mm_srai_epi32(r, 31);
+
+    return r;
+  #else
+    simde__m128i_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = ((k >> i) & 1) ? ~INT64_C(0) : INT64_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_movm_epi64
+  #define _mm_movm_epi64(k) simde_mm_movm_epi64(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_movm_epi64 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_movm_epi64(k);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const simde__m256i shifts = simde_mm256_set_epi32(28, 28, 29, 29, 30, 30, 31, 31);
+    simde__m256i r;
+
+    r = simde_mm256_set1_epi32(HEDLEY_STATIC_CAST(int, k));
+    r = simde_mm256_sllv_epi32(r, shifts);
+    r = simde_mm256_srai_epi32(r, 31);
+
+    return r;
+  #else
+    simde__m256i_private r_;
+
+    /* N.B. CM: This fallback may not be faster as there are only four elements */
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_movm_epi64(k     );
+      r_.m128i[1] = simde_mm_movm_epi64(k >> 2);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? ~INT64_C(0) : INT64_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movm_epi64
+  #define _mm256_movm_epi64(k) simde_mm256_movm_epi64(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_movm_epi64 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_movm_epi64(k);
+  #else
+    simde__m512i_private r_;
+
+    /* N.B. CM: Without AVX2 this fallback may not be faster as there are only eight elements */
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_movm_epi64(k     );
+      r_.m256i[1] = simde_mm256_movm_epi64(k >> 4);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? ~INT64_C(0) : INT64_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movm_epi64
+  #define _mm512_movm_epi64(k) simde_mm512_movm_epi64(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_mov_epi8 (simde__m128i src, simde__mmask16 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_epi8(src, k, a);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return simde_mm_blendv_epi8(src, a, simde_mm_movm_epi8(k));
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    simde__m128i mask = simde_mm_movm_epi8(k);
+    return simde_mm_or_si128(simde_mm_and_si128(mask, a), simde_mm_andnot_si128(mask, src));
+  #else
+    simde__m128i_private
+      src_ = simde__m128i_to_private(src),
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : src_.i8[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_epi8
+  #define _mm_mask_mov_epi8(src, k, a) simde_mm_mask_mov_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_mov_epi16 (simde__m128i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_epi16(src, k, a);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return simde_mm_blendv_epi8(src, a, simde_mm_movm_epi16(k));
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    simde__m128i mask = simde_mm_movm_epi16(k);
+    return simde_mm_or_si128(simde_mm_and_si128(mask, a), simde_mm_andnot_si128(mask, src));
+  #else
+    simde__m128i_private
+      src_ = simde__m128i_to_private(src),
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : src_.i16[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_epi16
+  #define _mm_mask_mov_epi16(src, k, a) simde_mm_mask_mov_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_mov_epi32 (simde__m128i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_epi32(src, k, a);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return simde_mm_blendv_epi8(src, a, simde_mm_movm_epi32(k));
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    simde__m128i mask = simde_mm_movm_epi32(k);
+    return simde_mm_or_si128(simde_mm_and_si128(mask, a), simde_mm_andnot_si128(mask, src));
+  #else
+    simde__m128i_private
+      src_ = simde__m128i_to_private(src),
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : src_.i32[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_epi32
+  #define _mm_mask_mov_epi32(src, k, a) simde_mm_mask_mov_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_mov_epi64 (simde__m128i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_epi64(src, k, a);
+  #else
+    simde__m128i_private
+      src_ = simde__m128i_to_private(src),
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    /* N.B. CM: No fallbacks as there are only two elements */
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : src_.i64[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_epi64
+  #define _mm_mask_mov_epi64(src, k, a) simde_mm_mask_mov_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_mask_mov_pd(simde__m128d src, simde__mmask8 k, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_pd(src, k, a);
+  #else
+    return simde_mm_castsi128_pd(simde_mm_mask_mov_epi64(simde_mm_castpd_si128(src), k, simde_mm_castpd_si128(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_pd
+  #define _mm_mask_mov_pd(src, k, a) simde_mm_mask_mov_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_mask_mov_ps (simde__m128 src, simde__mmask8 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_ps(src, k, a);
+  #else
+    return simde_mm_castsi128_ps(simde_mm_mask_mov_epi32(simde_mm_castps_si128(src), k, simde_mm_castps_si128(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_ps
+  #define _mm_mask_mov_ps(src, k, a) simde_mm_mask_mov_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_mov_epi8 (simde__m256i src, simde__mmask32 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_epi8(src, k, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_mm256_blendv_epi8(src, a, simde_mm256_movm_epi8(k));
+  #else
+    simde__m256i_private
+      r_,
+      src_ = simde__m256i_to_private(src),
+      a_ = simde__m256i_to_private(a);
+
+    #if defined(SIMDE_X86_SSSE3_NATIVE)
+      r_.m128i[0] = simde_mm_mask_mov_epi8(src_.m128i[0], HEDLEY_STATIC_CAST(simde__mmask16, k      ), a_.m128i[0]);
+      r_.m128i[1] = simde_mm_mask_mov_epi8(src_.m128i[1], HEDLEY_STATIC_CAST(simde__mmask16, k >> 16), a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : src_.i8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_epi8
+  #define _mm256_mask_mov_epi8(src, k, a) simde_mm256_mask_mov_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_mov_epi16 (simde__m256i src, simde__mmask16 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_epi16(src, k, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_mm256_blendv_epi8(src, a, simde_mm256_movm_epi16(k));
+  #else
+    simde__m256i_private
+      src_ = simde__m256i_to_private(src),
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_mask_mov_epi16(src_.m128i[0], HEDLEY_STATIC_CAST(simde__mmask8, k     ), a_.m128i[0]);
+      r_.m128i[1] = simde_mm_mask_mov_epi16(src_.m128i[1], HEDLEY_STATIC_CAST(simde__mmask8, k >> 8), a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : src_.i16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_epi16
+  #define _mm256_mask_mov_epi16(src, k, a) simde_mm256_mask_mov_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_mov_epi32 (simde__m256i src, simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_epi32(src, k, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_mm256_blendv_epi8(src, a, simde_mm256_movm_epi32(k));
+  #else
+    simde__m256i_private
+      src_ = simde__m256i_to_private(src),
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_mask_mov_epi32(src_.m128i[0], k     , a_.m128i[0]);
+      r_.m128i[1] = simde_mm_mask_mov_epi32(src_.m128i[1], k >> 4, a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : src_.i32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_epi32
+  #define _mm256_mask_mov_epi32(src, k, a) simde_mm256_mask_mov_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_mov_epi64 (simde__m256i src, simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_epi64(src, k, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_mm256_blendv_epi8(src, a, simde_mm256_movm_epi64(k));
+  #else
+    simde__m256i_private
+      src_ = simde__m256i_to_private(src),
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    /* N.B. CM: This fallback may not be faster as there are only four elements */
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_mask_mov_epi64(src_.m128i[0], k     , a_.m128i[0]);
+      r_.m128i[1] = simde_mm_mask_mov_epi64(src_.m128i[1], k >> 2, a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : src_.i64[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_epi64
+  #define _mm256_mask_mov_epi64(src, k, a) simde_mm256_mask_mov_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_mask_mov_pd (simde__m256d src, simde__mmask8 k, simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_pd(src, k, a);
+  #else
+    return simde_mm256_castsi256_pd(simde_mm256_mask_mov_epi64(simde_mm256_castpd_si256(src), k, simde_mm256_castpd_si256(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_pd
+  #define _mm256_mask_mov_pd(src, k, a) simde_mm256_mask_mov_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_mask_mov_ps (simde__m256 src, simde__mmask8 k, simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_ps(src, k, a);
+  #else
+    return simde_mm256_castsi256_ps(simde_mm256_mask_mov_epi32(simde_mm256_castps_si256(src), k, simde_mm256_castps_si256(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_ps
+  #define _mm256_mask_mov_ps(src, k, a) simde_mm256_mask_mov_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mov_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_mov_epi8(src, k, a);
+  #else
+    simde__m512i_private
+      src_ = simde__m512i_to_private(src),
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSSE3_NATIVE)
+      r_.m256i[0] = simde_mm256_mask_mov_epi8(src_.m256i[0], HEDLEY_STATIC_CAST(simde__mmask32, k      ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_mask_mov_epi8(src_.m256i[1], HEDLEY_STATIC_CAST(simde__mmask32, k >> 32), a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : src_.i8[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_epi8
+  #define _mm512_mask_mov_epi8(src, k, a) simde_mm512_mask_mov_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mov_epi16 (simde__m512i src, simde__mmask32 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_mov_epi16(src, k, a);
+  #else
+    simde__m512i_private
+      src_ = simde__m512i_to_private(src),
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_mask_mov_epi16(src_.m256i[0], HEDLEY_STATIC_CAST(simde__mmask16, k      ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_mask_mov_epi16(src_.m256i[1], HEDLEY_STATIC_CAST(simde__mmask16, k >> 16), a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : src_.i16[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_epi16
+  #define _mm512_mask_mov_epi16(src, k, a) simde_mm512_mask_mov_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mov_epi32 (simde__m512i src, simde__mmask16 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mov_epi32(src, k, a);
+  #else
+    simde__m512i_private
+      src_ = simde__m512i_to_private(src),
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_mask_mov_epi32(src_.m256i[0], HEDLEY_STATIC_CAST(simde__mmask8, k     ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_mask_mov_epi32(src_.m256i[1], HEDLEY_STATIC_CAST(simde__mmask8, k >> 8), a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : src_.i32[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_epi32
+  #define _mm512_mask_mov_epi32(src, k, a) simde_mm512_mask_mov_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mov_epi64 (simde__m512i src, simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mov_epi64(src, k, a);
+  #else
+    simde__m512i_private
+      src_ = simde__m512i_to_private(src),
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    /* N.B. CM: Without AVX2 this fallback may not be faster as there are only eight elements */
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_mask_mov_epi64(src_.m256i[0], k     , a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_mask_mov_epi64(src_.m256i[1], k >> 4, a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : src_.i64[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_epi64
+  #define _mm512_mask_mov_epi64(src, k, a) simde_mm512_mask_mov_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_mov_pd (simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mov_pd(src, k, a);
+  #else
+    return simde_mm512_castsi512_pd(simde_mm512_mask_mov_epi64(simde_mm512_castpd_si512(src), k, simde_mm512_castpd_si512(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_pd
+  #define _mm512_mask_mov_pd(src, k, a) simde_mm512_mask_mov_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_mov_ps (simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mov_ps(src, k, a);
+  #else
+    return simde_mm512_castsi512_ps(simde_mm512_mask_mov_epi32(simde_mm512_castps_si512(src), k, simde_mm512_castps_si512(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_ps
+  #define _mm512_mask_mov_ps(src, k, a) simde_mm512_mask_mov_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_mov_epi8 (simde__mmask16 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_epi8(k, a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return simde_mm_and_si128(a, simde_mm_movm_epi8(k));
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : INT8_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_epi8
+  #define _mm_maskz_mov_epi8(k, a) simde_mm_maskz_mov_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_mov_epi16 (simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_epi16(k, a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return simde_mm_and_si128(a, simde_mm_movm_epi16(k));
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : INT16_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_epi16
+  #define _mm_maskz_mov_epi16(k, a) simde_mm_maskz_mov_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_mov_epi32 (simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_epi32(k, a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return simde_mm_and_si128(a, simde_mm_movm_epi32(k));
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : INT32_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_epi32
+  #define _mm_maskz_mov_epi32(k, a) simde_mm_maskz_mov_epi32(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_mov_epi64 (simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_epi64(k, a);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    /* N.B. CM: No fallbacks as there are only two elements */
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : INT64_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_epi64
+  #define _mm_maskz_mov_epi64(k, a) simde_mm_maskz_mov_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_maskz_mov_pd (simde__mmask8 k, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_pd(k, a);
+  #else
+    return simde_mm_castsi128_pd(simde_mm_maskz_mov_epi64(k, simde_mm_castpd_si128(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_pd
+  #define _mm_maskz_mov_pd(k, a) simde_mm_maskz_mov_pd(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_maskz_mov_ps (simde__mmask8 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_ps(k, a);
+  #else
+    return simde_mm_castsi128_ps(simde_mm_maskz_mov_epi32(k, simde_mm_castps_si128(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_ps
+  #define _mm_maskz_mov_ps(k, a) simde_mm_maskz_mov_ps(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_mov_epi8 (simde__mmask32 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_epi8(k, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_mm256_and_si256(a, simde_mm256_movm_epi8(k));
+  #else
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSSE3_NATIVE)
+      r_.m128i[0] = simde_mm_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k      ), a_.m128i[0]);
+      r_.m128i[1] = simde_mm_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k >> 16), a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : INT8_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_epi8
+  #define _mm256_maskz_mov_epi8(k, a) simde_mm256_maskz_mov_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_mov_epi16 (simde__mmask16 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_epi16(k, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_mm256_and_si256(a, simde_mm256_movm_epi16(k));
+  #else
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_maskz_mov_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k     ), a_.m128i[0]);
+      r_.m128i[1] = simde_mm_maskz_mov_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k >> 8), a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : INT16_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_epi16
+  #define _mm256_maskz_mov_epi16(k, a) simde_mm256_maskz_mov_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_mov_epi32 (simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_epi32(k, a);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_mm256_and_si256(a, simde_mm256_movm_epi32(k));
+  #else
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_maskz_mov_epi32(k     , a_.m128i[0]);
+      r_.m128i[1] = simde_mm_maskz_mov_epi32(k >> 4, a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : INT32_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_epi32
+  #define _mm256_maskz_mov_epi32(k, a) simde_mm256_maskz_mov_epi32(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_mov_epi64 (simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_epi64(k, a);
+  #else
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    /* N.B. CM: This fallback may not be faster as there are only four elements */
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_maskz_mov_epi64(k     , a_.m128i[0]);
+      r_.m128i[1] = simde_mm_maskz_mov_epi64(k >> 2, a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : INT64_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_epi64
+  #define _mm256_maskz_mov_epi64(k, a) simde_mm256_maskz_mov_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_maskz_mov_pd (simde__mmask8 k, simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_pd(k, a);
+  #else
+    return simde_mm256_castsi256_pd(simde_mm256_maskz_mov_epi64(k, simde_mm256_castpd_si256(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_pd
+  #define _mm256_maskz_mov_pd(k, a) simde_mm256_maskz_mov_pd(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_maskz_mov_ps (simde__mmask8 k, simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_ps(k, a);
+  #else
+    return simde_mm256_castsi256_ps(simde_mm256_maskz_mov_epi32(k, simde_mm256_castps_si256(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_ps
+  #define _mm256_maskz_mov_ps(k, a) simde_mm256_maskz_mov_ps(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mov_epi8 (simde__mmask64 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_mov_epi8(k, a);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSSE3_NATIVE)
+      r_.m256i[0] = simde_mm256_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k      ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k >> 32), a_.m256i[1]);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : INT8_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_epi8
+  #define _mm512_maskz_mov_epi8(k, a) simde_mm512_maskz_mov_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mov_epi16 (simde__mmask32 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_mov_epi16(k, a);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_maskz_mov_epi16(HEDLEY_STATIC_CAST(simde__mmask16, k      ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_maskz_mov_epi16(HEDLEY_STATIC_CAST(simde__mmask16, k >> 16), a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : INT16_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_epi16
+  #define _mm512_maskz_mov_epi16(k, a) simde_mm512_maskz_mov_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mov_epi32 (simde__mmask16 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mov_epi32(k, a);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_maskz_mov_epi32(HEDLEY_STATIC_CAST(simde__mmask8, k     ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_maskz_mov_epi32(HEDLEY_STATIC_CAST(simde__mmask8, k >> 8), a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : INT32_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_epi32
+  #define _mm512_maskz_mov_epi32(k, a) simde_mm512_maskz_mov_epi32(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mov_epi64 (simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mov_epi64(k, a);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    /* N.B. CM: Without AVX2 this fallback may not be faster as there are only eight elements */
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_maskz_mov_epi64(k     , a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_maskz_mov_epi64(k >> 4, a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : INT64_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_epi64
+  #define _mm512_maskz_mov_epi64(k, a) simde_mm512_maskz_mov_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_mov_pd (simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mov_pd(k, a);
+  #else
+    return simde_mm512_castsi512_pd(simde_mm512_maskz_mov_epi64(k, simde_mm512_castpd_si512(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_pd
+  #define _mm512_maskz_mov_pd(k, a) simde_mm512_maskz_mov_pd(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_mov_ps (simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mov_ps(k, a);
+  #else
+    return simde_mm512_castsi512_ps(simde_mm512_maskz_mov_epi32(k, simde_mm512_castps_si512(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_ps
+  #define _mm512_maskz_mov_ps(k, a) simde_mm512_maskz_mov_ps(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_movepi8_mask (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_movepi8_mask(a);
+  #else
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+    simde__mmask64 r;
+
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      r =             HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm256_movemask_epi8(a_.m256i[1])));
+      r = (r << 32) | HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm256_movemask_epi8(a_.m256i[0])));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r =             HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm_movemask_epi8(a_.m128i[3])));
+      r = (r << 16) | HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm_movemask_epi8(a_.m128i[2])));
+      r = (r << 16) | HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm_movemask_epi8(a_.m128i[1])));
+      r = (r << 16) | HEDLEY_STATIC_CAST(simde__mmask64, HEDLEY_STATIC_CAST(unsigned int, simde_mm_movemask_epi8(a_.m128i[0])));
+    #else
+      r = 0;
+
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++) {
+        r |= (a_.i8[i] < 0) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movepi8_mask
+  #define _mm512_movepi8_mask(a) simde_mm512_movepi8_mask(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask32
+simde_mm512_movepi16_mask (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_movepi16_mask(a);
+  #else
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+    simde__mmask32 r = 0;
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.i16) / sizeof(a_.i16[0])) ; i++) {
+      r |= (a_.i16[i] < 0) ? (UINT32_C(1) << i) : 0;
+    }
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movepi16_mask
+  #define _mm512_movepi16_mask(a) simde_mm512_movepi16_mask(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask16
+simde_mm512_movepi32_mask (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_movepi32_mask(a);
+  #else
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+    simde__mmask16 r = 0;
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r |= (a_.i32[i] < 0) ? (UINT32_C(1) << i) : 0;
+    }
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movepi32_mask
+  #define _mm512_movepi32_mask(a) simde_mm512_movepi32_mask(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask8
+simde_mm512_movepi64_mask (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_movepi64_mask(a);
+  #else
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+    simde__mmask8 r = 0;
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r |= (a_.i64[i] < 0) ? (UINT32_C(1) << i) : 0;
+    }
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movepi64_mask
+  #define _mm512_movepi64_mask(a) simde_mm512_movepi64_mask(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES

--- a/test/x86/avx512f.c
+++ b/test/x86/avx512f.c
@@ -14546,6 +14546,112 @@ test_simde_mm_mask_mov_epi64(const MunitParameter params[], void* data) {
 }
 
 static MunitResult
+test_simde_mm_mask_mov_pd(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__m128d src;
+    simde__mmask8 k;
+    simde__m128d a;
+    simde__m128d r;
+  } test_vec[8] = {
+    { simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C(    0.00)),
+      UINT8_C(210),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(   55.56), SIMDE_FLOAT64_C(  306.20)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(   55.56), SIMDE_FLOAT64_C(    0.00)) },
+    { simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C(    0.00)),
+      UINT8_C(  7),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  202.21), SIMDE_FLOAT64_C( -678.71)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  202.21), SIMDE_FLOAT64_C( -678.71)) },
+    { simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C(    0.00)),
+      UINT8_C( 50),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  680.40), SIMDE_FLOAT64_C(  906.67)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  680.40), SIMDE_FLOAT64_C(    0.00)) },
+    { simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C(    0.00)),
+      UINT8_C(229),
+      simde_mm_set_pd(SIMDE_FLOAT64_C( -422.72), SIMDE_FLOAT64_C(  572.83)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C(  572.83)) },
+    { simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C(    0.00)),
+      UINT8_C(117),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  -76.19), SIMDE_FLOAT64_C( -654.60)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C( -654.60)) },
+    { simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C(    0.00)),
+      UINT8_C(130),
+      simde_mm_set_pd(SIMDE_FLOAT64_C( -711.42), SIMDE_FLOAT64_C(  -22.70)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C( -711.42), SIMDE_FLOAT64_C(    0.00)) },
+    { simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C(    0.00)),
+      UINT8_C( 62),
+      simde_mm_set_pd(SIMDE_FLOAT64_C( -413.23), SIMDE_FLOAT64_C(  547.52)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C( -413.23), SIMDE_FLOAT64_C(    0.00)) },
+    { simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C(    0.00)),
+      UINT8_C(165),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  575.41), SIMDE_FLOAT64_C( -702.01)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C( -702.01)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m128d r = simde_mm_mask_mov_pd(test_vec[i].src, test_vec[i].k, test_vec[i].a);
+    simde_assert_m128d_close(r, test_vec[i].r, 1);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
+test_simde_mm_mask_mov_ps(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__m128 src;
+    simde__mmask8 k;
+    simde__m128 a;
+    simde__m128 r;
+  } test_vec[8] = {
+    { simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)),
+      UINT16_C(  126),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(  -678.71), SIMDE_FLOAT32_C(   675.53), SIMDE_FLOAT32_C(    55.56), SIMDE_FLOAT32_C(   306.20)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(  -678.71), SIMDE_FLOAT32_C(   675.53), SIMDE_FLOAT32_C(    55.56), SIMDE_FLOAT32_C(     0.00)) },
+    { simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)),
+      UINT16_C(   44),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   941.87), SIMDE_FLOAT32_C(   680.40), SIMDE_FLOAT32_C(   906.67), SIMDE_FLOAT32_C(  -364.25)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   941.87), SIMDE_FLOAT32_C(   680.40), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)) },
+    { simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)),
+      UINT16_C(  117),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   -76.19), SIMDE_FLOAT32_C(  -654.60), SIMDE_FLOAT32_C(  -721.91), SIMDE_FLOAT32_C(  -422.72)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -654.60), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -422.72)) },
+    { simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)),
+      UINT16_C(   76),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   547.52), SIMDE_FLOAT32_C(  -627.17), SIMDE_FLOAT32_C(  -711.42), SIMDE_FLOAT32_C(   -22.70)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   547.52), SIMDE_FLOAT32_C(  -627.17), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)) },
+    { simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)),
+      UINT16_C(  101),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(  -822.97), SIMDE_FLOAT32_C(   575.41), SIMDE_FLOAT32_C(  -702.01), SIMDE_FLOAT32_C(  -488.76)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   575.41), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -488.76)) },
+    { simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)),
+      UINT16_C(  149),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   804.55), SIMDE_FLOAT32_C(  -888.85), SIMDE_FLOAT32_C(   750.71), SIMDE_FLOAT32_C(   346.51)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -888.85), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   346.51)) },
+    { simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)),
+      UINT16_C(  115),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   -17.38), SIMDE_FLOAT32_C(   623.33), SIMDE_FLOAT32_C(   459.80), SIMDE_FLOAT32_C(   837.15)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   459.80), SIMDE_FLOAT32_C(   837.15)) },
+    { simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)),
+      UINT16_C(   50),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   197.69), SIMDE_FLOAT32_C(   233.42), SIMDE_FLOAT32_C(   153.73), SIMDE_FLOAT32_C(   616.58)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   153.73), SIMDE_FLOAT32_C(     0.00)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m128 r = simde_mm_mask_mov_ps(test_vec[i].src, test_vec[i].k, test_vec[i].a);
+    simde_assert_m128_close(r, test_vec[i].r, 1);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
 test_simde_mm256_mask_mov_epi8(const MunitParameter params[], void* data) {
   (void) params;
   (void) data;
@@ -16616,6 +16722,94 @@ test_simde_mm_maskz_mov_epi64(const MunitParameter params[], void* data) {
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
     simde__m128i r = simde_mm_maskz_mov_epi64(test_vec[i].k, test_vec[i].a);
     simde_assert_m128i_i64(r, ==, test_vec[i].r);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
+test_simde_mm_maskz_mov_pd(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__mmask8 k;
+    simde__m128d a;
+    simde__m128d r;
+  } test_vec[8] = {
+    { UINT8_C(210),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(   55.56), SIMDE_FLOAT64_C(  306.20)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(   55.56), SIMDE_FLOAT64_C(    0.00)) },
+    { UINT8_C(  7),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  202.21), SIMDE_FLOAT64_C( -678.71)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  202.21), SIMDE_FLOAT64_C( -678.71)) },
+    { UINT8_C( 50),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  680.40), SIMDE_FLOAT64_C(  906.67)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  680.40), SIMDE_FLOAT64_C(    0.00)) },
+    { UINT8_C(229),
+      simde_mm_set_pd(SIMDE_FLOAT64_C( -422.72), SIMDE_FLOAT64_C(  572.83)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C(  572.83)) },
+    { UINT8_C(117),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  -76.19), SIMDE_FLOAT64_C( -654.60)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C( -654.60)) },
+    { UINT8_C(130),
+      simde_mm_set_pd(SIMDE_FLOAT64_C( -711.42), SIMDE_FLOAT64_C(  -22.70)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C( -711.42), SIMDE_FLOAT64_C(    0.00)) },
+    { UINT8_C( 62),
+      simde_mm_set_pd(SIMDE_FLOAT64_C( -413.23), SIMDE_FLOAT64_C(  547.52)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C( -413.23), SIMDE_FLOAT64_C(    0.00)) },
+    { UINT8_C(165),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(  575.41), SIMDE_FLOAT64_C( -702.01)),
+      simde_mm_set_pd(SIMDE_FLOAT64_C(    0.00), SIMDE_FLOAT64_C( -702.01)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m128d r = simde_mm_maskz_mov_pd(test_vec[i].k, test_vec[i].a);
+    simde_assert_m128d_close(r, test_vec[i].r, 1);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
+test_simde_mm_maskz_mov_ps(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__mmask8 k;
+    simde__m128 a;
+    simde__m128 r;
+  } test_vec[8] = {
+    { UINT16_C(  126),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(  -678.71), SIMDE_FLOAT32_C(   675.53), SIMDE_FLOAT32_C(    55.56), SIMDE_FLOAT32_C(   306.20)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(  -678.71), SIMDE_FLOAT32_C(   675.53), SIMDE_FLOAT32_C(    55.56), SIMDE_FLOAT32_C(     0.00)) },
+    { UINT16_C(   44),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   941.87), SIMDE_FLOAT32_C(   680.40), SIMDE_FLOAT32_C(   906.67), SIMDE_FLOAT32_C(  -364.25)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   941.87), SIMDE_FLOAT32_C(   680.40), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)) },
+    { UINT16_C(  117),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   -76.19), SIMDE_FLOAT32_C(  -654.60), SIMDE_FLOAT32_C(  -721.91), SIMDE_FLOAT32_C(  -422.72)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -654.60), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -422.72)) },
+    { UINT16_C(   76),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   547.52), SIMDE_FLOAT32_C(  -627.17), SIMDE_FLOAT32_C(  -711.42), SIMDE_FLOAT32_C(   -22.70)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   547.52), SIMDE_FLOAT32_C(  -627.17), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00)) },
+    { UINT16_C(  101),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(  -822.97), SIMDE_FLOAT32_C(   575.41), SIMDE_FLOAT32_C(  -702.01), SIMDE_FLOAT32_C(  -488.76)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   575.41), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -488.76)) },
+    { UINT16_C(  149),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   804.55), SIMDE_FLOAT32_C(  -888.85), SIMDE_FLOAT32_C(   750.71), SIMDE_FLOAT32_C(   346.51)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(  -888.85), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   346.51)) },
+    { UINT16_C(  115),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   -17.38), SIMDE_FLOAT32_C(   623.33), SIMDE_FLOAT32_C(   459.80), SIMDE_FLOAT32_C(   837.15)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   459.80), SIMDE_FLOAT32_C(   837.15)) },
+    { UINT16_C(   50),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(   197.69), SIMDE_FLOAT32_C(   233.42), SIMDE_FLOAT32_C(   153.73), SIMDE_FLOAT32_C(   616.58)),
+      simde_mm_set_ps(SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(     0.00), SIMDE_FLOAT32_C(   153.73), SIMDE_FLOAT32_C(     0.00)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m128 r = simde_mm_maskz_mov_ps(test_vec[i].k, test_vec[i].a);
+    simde_assert_m128_close(r, test_vec[i].r, 1);
   }
 
   return MUNIT_OK;
@@ -18721,6 +18915,97 @@ test_simde_mm256_movm_epi16(const MunitParameter params[], void* data) {
 }
 
 static MunitResult
+test_simde_mm512_movm_epi16(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__mmask32 k;
+    simde__m512i r;
+  } test_vec[8] = {
+    { UINT32_C(2805036472),
+      simde_mm512_set_epi16(INT16_C(    -1), INT16_C(     0), INT16_C(    -1), INT16_C(     0),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(     0), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(     0), INT16_C(     0), INT16_C(     0)) },
+    { UINT32_C(2266796856),
+      simde_mm512_set_epi16(INT16_C(    -1), INT16_C(     0), INT16_C(     0), INT16_C(     0),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(    -1), INT16_C(     0), INT16_C(     0),
+                            INT16_C(    -1), INT16_C(     0), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(     0), INT16_C(     0), INT16_C(     0)) },
+    { UINT32_C(3598176466),
+      simde_mm512_set_epi16(INT16_C(    -1), INT16_C(    -1), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(     0),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(    -1), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(     0),
+                            INT16_C(    -1), INT16_C(    -1), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(    -1), INT16_C(     0)) },
+    { UINT32_C( 689971098),
+      simde_mm512_set_epi16(INT16_C(     0), INT16_C(     0), INT16_C(    -1), INT16_C(     0),
+                            INT16_C(    -1), INT16_C(     0), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(    -1), INT16_C(     0),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(     0),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(     0), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(     0), INT16_C(    -1), INT16_C(     0)) },
+    { UINT32_C(2581729150),
+      simde_mm512_set_epi16(INT16_C(    -1), INT16_C(     0), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(     0), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(    -1), INT16_C(    -1), INT16_C(     0),
+                            INT16_C(     0), INT16_C(     0), INT16_C(    -1), INT16_C(     0),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(     0),
+                            INT16_C(    -1), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(    -1), INT16_C(    -1), INT16_C(     0)) },
+    { UINT32_C(1365267719),
+      simde_mm512_set_epi16(INT16_C(     0), INT16_C(    -1), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(     0),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(     0),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(     0),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1)) },
+    { UINT32_C(4094538289),
+      simde_mm512_set_epi16(INT16_C(    -1), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(     0), INT16_C(     0),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(     0),
+                            INT16_C(    -1), INT16_C(    -1), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(    -1), INT16_C(     0), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(    -1), INT16_C(     0),
+                            INT16_C(     0), INT16_C(     0), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(    -1)) },
+    { UINT32_C(3608627761),
+      simde_mm512_set_epi16(INT16_C(    -1), INT16_C(    -1), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(    -1), INT16_C(     0), INT16_C(     0),
+                            INT16_C(    -1), INT16_C(     0), INT16_C(    -1), INT16_C(     0),
+                            INT16_C(     0), INT16_C(     0), INT16_C(    -1), INT16_C(    -1),
+                            INT16_C(     0), INT16_C(     0), INT16_C(     0), INT16_C(    -1)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m512i r = simde_mm512_movm_epi16(test_vec[i].k);
+    simde_assert_m512i_i16(r, ==, test_vec[i].r);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
 test_simde_mm_movm_epi32(const MunitParameter params[], void* data) {
   (void) params;
   (void) data;
@@ -18793,6 +19078,202 @@ test_simde_mm256_movm_epi32(const MunitParameter params[], void* data) {
   for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
     simde__m256i r = simde_mm256_movm_epi32(test_vec[i].k);
     simde_assert_m256i_i32(r, ==, test_vec[i].r);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
+test_simde_mm512_movm_epi32(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__mmask16 k;
+    simde__m512i r;
+  } test_vec[8] = {
+    { UINT16_C(30136),
+      simde_mm512_set_epi32(INT32_C(          0), INT32_C(         -1), INT32_C(         -1), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(         -1), INT32_C(          0), INT32_C(         -1),
+                            INT32_C(         -1), INT32_C(          0), INT32_C(         -1), INT32_C(         -1),
+                            INT32_C(         -1), INT32_C(          0), INT32_C(          0), INT32_C(          0)) },
+    { UINT16_C(37688),
+      simde_mm512_set_epi32(INT32_C(         -1), INT32_C(          0), INT32_C(          0), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(          0), INT32_C(         -1), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(          0), INT32_C(         -1), INT32_C(         -1),
+                            INT32_C(         -1), INT32_C(          0), INT32_C(          0), INT32_C(          0)) },
+    { UINT16_C(53458),
+      simde_mm512_set_epi32(INT32_C(         -1), INT32_C(         -1), INT32_C(          0), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(          0), INT32_C(          0), INT32_C(          0),
+                            INT32_C(         -1), INT32_C(         -1), INT32_C(          0), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(          0), INT32_C(         -1), INT32_C(          0)) },
+    { UINT16_C( 8090),
+      simde_mm512_set_epi32(INT32_C(          0), INT32_C(          0), INT32_C(          0), INT32_C(         -1),
+                            INT32_C(         -1), INT32_C(         -1), INT32_C(         -1), INT32_C(         -1),
+                            INT32_C(         -1), INT32_C(          0), INT32_C(          0), INT32_C(         -1),
+                            INT32_C(         -1), INT32_C(          0), INT32_C(         -1), INT32_C(          0)) },
+    { UINT16_C( 3966),
+      simde_mm512_set_epi32(INT32_C(          0), INT32_C(          0), INT32_C(          0), INT32_C(          0),
+                            INT32_C(         -1), INT32_C(         -1), INT32_C(         -1), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(         -1), INT32_C(         -1), INT32_C(         -1),
+                            INT32_C(         -1), INT32_C(         -1), INT32_C(         -1), INT32_C(          0)) },
+    { UINT16_C(21767),
+      simde_mm512_set_epi32(INT32_C(          0), INT32_C(         -1), INT32_C(          0), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(         -1), INT32_C(          0), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(          0), INT32_C(          0), INT32_C(          0),
+                            INT32_C(          0), INT32_C(         -1), INT32_C(         -1), INT32_C(         -1)) },
+    { UINT16_C(45617),
+      simde_mm512_set_epi32(INT32_C(         -1), INT32_C(          0), INT32_C(         -1), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(          0), INT32_C(         -1), INT32_C(          0),
+                            INT32_C(          0), INT32_C(          0), INT32_C(         -1), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(          0), INT32_C(          0), INT32_C(         -1)) },
+    { UINT16_C(18993),
+      simde_mm512_set_epi32(INT32_C(          0), INT32_C(         -1), INT32_C(          0), INT32_C(          0),
+                            INT32_C(         -1), INT32_C(          0), INT32_C(         -1), INT32_C(          0),
+                            INT32_C(          0), INT32_C(          0), INT32_C(         -1), INT32_C(         -1),
+                            INT32_C(          0), INT32_C(          0), INT32_C(          0), INT32_C(         -1)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m512i r = simde_mm512_movm_epi32(test_vec[i].k);
+    simde_assert_m512i_i32(r, ==, test_vec[i].r);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
+test_simde_mm_movm_epi64(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__mmask8 k;
+    simde__m128i r;
+  } test_vec[8] = {
+    { UINT8_C(184),
+      simde_mm_set_epi64x(INT64_C(                   0), INT64_C(                   0)) },
+    { UINT8_C( 56),
+      simde_mm_set_epi64x(INT64_C(                   0), INT64_C(                   0)) },
+    { UINT8_C(210),
+      simde_mm_set_epi64x(INT64_C(                  -1), INT64_C(                   0)) },
+    { UINT8_C(154),
+      simde_mm_set_epi64x(INT64_C(                  -1), INT64_C(                   0)) },
+    { UINT8_C(126),
+      simde_mm_set_epi64x(INT64_C(                  -1), INT64_C(                   0)) },
+    { UINT8_C(  7),
+      simde_mm_set_epi64x(INT64_C(                  -1), INT64_C(                  -1)) },
+    { UINT8_C( 49),
+      simde_mm_set_epi64x(INT64_C(                   0), INT64_C(                  -1)) },
+    { UINT8_C( 49),
+      simde_mm_set_epi64x(INT64_C(                   0), INT64_C(                  -1)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m128i r = simde_mm_movm_epi64(test_vec[i].k);
+    simde_assert_m128i_i64(r, ==, test_vec[i].r);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
+test_simde_mm256_movm_epi64(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__mmask8 k;
+    simde__m256i r;
+  } test_vec[8] = {
+    { UINT8_C(184),
+      simde_mm256_set_epi64x(INT64_C(                  -1), INT64_C(                   0),
+                             INT64_C(                   0), INT64_C(                   0)) },
+    { UINT8_C( 56),
+      simde_mm256_set_epi64x(INT64_C(                  -1), INT64_C(                   0),
+                             INT64_C(                   0), INT64_C(                   0)) },
+    { UINT8_C(210),
+      simde_mm256_set_epi64x(INT64_C(                   0), INT64_C(                   0),
+                             INT64_C(                  -1), INT64_C(                   0)) },
+    { UINT8_C(154),
+      simde_mm256_set_epi64x(INT64_C(                  -1), INT64_C(                   0),
+                             INT64_C(                  -1), INT64_C(                   0)) },
+    { UINT8_C(126),
+      simde_mm256_set_epi64x(INT64_C(                  -1), INT64_C(                  -1),
+                             INT64_C(                  -1), INT64_C(                   0)) },
+    { UINT8_C(  7),
+      simde_mm256_set_epi64x(INT64_C(                   0), INT64_C(                  -1),
+                             INT64_C(                  -1), INT64_C(                  -1)) },
+    { UINT8_C( 49),
+      simde_mm256_set_epi64x(INT64_C(                   0), INT64_C(                   0),
+                             INT64_C(                   0), INT64_C(                  -1)) },
+    { UINT8_C( 49),
+      simde_mm256_set_epi64x(INT64_C(                   0), INT64_C(                   0),
+                             INT64_C(                   0), INT64_C(                  -1)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m256i r = simde_mm256_movm_epi64(test_vec[i].k);
+    simde_assert_m256i_i64(r, ==, test_vec[i].r);
+  }
+
+  return MUNIT_OK;
+}
+
+static MunitResult
+test_simde_mm512_movm_epi64(const MunitParameter params[], void* data) {
+  (void) params;
+  (void) data;
+
+  const struct {
+    simde__mmask8 k;
+    simde__m512i r;
+  } test_vec[8] = {
+    { UINT8_C(184),
+      simde_mm512_set_epi64(INT64_C(                  -1), INT64_C(                   0),
+                            INT64_C(                  -1), INT64_C(                  -1),
+                            INT64_C(                  -1), INT64_C(                   0),
+                            INT64_C(                   0), INT64_C(                   0)) },
+    { UINT8_C( 56),
+      simde_mm512_set_epi64(INT64_C(                   0), INT64_C(                   0),
+                            INT64_C(                  -1), INT64_C(                  -1),
+                            INT64_C(                  -1), INT64_C(                   0),
+                            INT64_C(                   0), INT64_C(                   0)) },
+    { UINT8_C(210),
+      simde_mm512_set_epi64(INT64_C(                  -1), INT64_C(                  -1),
+                            INT64_C(                   0), INT64_C(                  -1),
+                            INT64_C(                   0), INT64_C(                   0),
+                            INT64_C(                  -1), INT64_C(                   0)) },
+    { UINT8_C(154),
+      simde_mm512_set_epi64(INT64_C(                  -1), INT64_C(                   0),
+                            INT64_C(                   0), INT64_C(                  -1),
+                            INT64_C(                  -1), INT64_C(                   0),
+                            INT64_C(                  -1), INT64_C(                   0)) },
+    { UINT8_C(126),
+      simde_mm512_set_epi64(INT64_C(                   0), INT64_C(                  -1),
+                            INT64_C(                  -1), INT64_C(                  -1),
+                            INT64_C(                  -1), INT64_C(                  -1),
+                            INT64_C(                  -1), INT64_C(                   0)) },
+    { UINT8_C(  7),
+      simde_mm512_set_epi64(INT64_C(                   0), INT64_C(                   0),
+                            INT64_C(                   0), INT64_C(                   0),
+                            INT64_C(                   0), INT64_C(                  -1),
+                            INT64_C(                  -1), INT64_C(                  -1)) },
+    { UINT8_C( 49),
+      simde_mm512_set_epi64(INT64_C(                   0), INT64_C(                   0),
+                            INT64_C(                  -1), INT64_C(                  -1),
+                            INT64_C(                   0), INT64_C(                   0),
+                            INT64_C(                   0), INT64_C(                  -1)) },
+    { UINT8_C( 49),
+      simde_mm512_set_epi64(INT64_C(                   0), INT64_C(                   0),
+                            INT64_C(                  -1), INT64_C(                  -1),
+                            INT64_C(                   0), INT64_C(                   0),
+                            INT64_C(                   0), INT64_C(                  -1)) },
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])); i++) {
+    simde__m512i r = simde_mm512_movm_epi64(test_vec[i].k);
+    simde_assert_m512i_i64(r, ==, test_vec[i].r);
   }
 
   return MUNIT_OK;
@@ -26125,6 +26606,8 @@ static MunitTest test_suite_tests[] = {
   SIMDE_TESTS_DEFINE_TEST(mm_mask_mov_epi16),
   SIMDE_TESTS_DEFINE_TEST(mm_mask_mov_epi32),
   SIMDE_TESTS_DEFINE_TEST(mm_mask_mov_epi64),
+  SIMDE_TESTS_DEFINE_TEST(mm_mask_mov_pd),
+  SIMDE_TESTS_DEFINE_TEST(mm_mask_mov_ps),
 
   SIMDE_TESTS_DEFINE_TEST(mm256_mask_mov_epi8),
   SIMDE_TESTS_DEFINE_TEST(mm256_mask_mov_epi16),
@@ -26144,6 +26627,8 @@ static MunitTest test_suite_tests[] = {
   SIMDE_TESTS_DEFINE_TEST(mm_maskz_mov_epi16),
   SIMDE_TESTS_DEFINE_TEST(mm_maskz_mov_epi32),
   SIMDE_TESTS_DEFINE_TEST(mm_maskz_mov_epi64),
+  SIMDE_TESTS_DEFINE_TEST(mm_maskz_mov_pd),
+  SIMDE_TESTS_DEFINE_TEST(mm_maskz_mov_ps),
 
   SIMDE_TESTS_DEFINE_TEST(mm256_maskz_mov_epi8),
   SIMDE_TESTS_DEFINE_TEST(mm256_maskz_mov_epi16),
@@ -26165,9 +26650,15 @@ static MunitTest test_suite_tests[] = {
 
   SIMDE_TESTS_DEFINE_TEST(mm_movm_epi16),
   SIMDE_TESTS_DEFINE_TEST(mm256_movm_epi16),
+  SIMDE_TESTS_DEFINE_TEST(mm512_movm_epi16),
 
   SIMDE_TESTS_DEFINE_TEST(mm_movm_epi32),
   SIMDE_TESTS_DEFINE_TEST(mm256_movm_epi32),
+  SIMDE_TESTS_DEFINE_TEST(mm512_movm_epi32),
+
+  SIMDE_TESTS_DEFINE_TEST(mm_movm_epi64),
+  SIMDE_TESTS_DEFINE_TEST(mm256_movm_epi64),
+  SIMDE_TESTS_DEFINE_TEST(mm512_movm_epi64),
 
   SIMDE_TESTS_DEFINE_TEST(mm512_movepi8_mask),
   SIMDE_TESTS_DEFINE_TEST(mm512_movepi16_mask),


### PR DESCRIPTION
Add _mm{,256}_movm_epi64
Add _mm512_movm_epi{16,32,64]
Add _mm_mask{,z}_mov_p[ds]

Some casts are needed so move casts to the beginning.
Add some fallbacks and clean up existing movm and mask{,z}_mov functions.
