### PR TITLE
sse4.2: implementation for mm_crc32_u8

### DIFF
--- a/simde/x86/sse4.2.h
+++ b/simde/x86/sse4.2.h
@@ -269,6 +269,25 @@ simde_mm_cmpistrz_16_(simde__m128i b) {
   #define _mm_cmpistrz(a, b, imm8) simde_mm_cmpistrz(a, b, imm8)
 #endif
 
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_mm_crc32_u8(uint32_t prevcrc, uint8_t v) {
+#if defined(SIMDE_X86_SSE4_2_NATIVE)
+  return _mm_crc32_u8(prevcrc, v);
+#else
+uint32_t crc = prevcrc;
+crc ^= v;
+for(int bit = 0; bit < 8 ; bit++){
+  if(crc & 1) crc = (crc >> 1)^(0x82f63b78);
+  else        crc = (crc >> 1);
+}
+return crc;
+#endif
+}
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES)
+#  define _mm_crc32_u8(prevcrc, v) simde_mm_crc32_u8(prevcrc, v)
+#endif
+
 SIMDE_END_DECLS_
 
 HEDLEY_DIAGNOSTIC_POP

--- a/test/x86/sse4.2.c
+++ b/test/x86/sse4.2.c
@@ -891,6 +891,49 @@ test_simde_mm_cmpistrz_16(void) {
   return 0;
 }
 
+static int
+test_simde_mm_crc32_u8 (void) {
+  static const struct {
+    uint32_t crc;
+    uint8_t v;
+    unsigned int r;
+  } test_vec[] = {
+    { UINT32_C(3488119326),
+      UINT8_C(233),
+      UINT32_C( 661382116) },
+    { UINT32_C(4181338815),
+      UINT8_C(106),
+      UINT32_C(3873165213) },
+    { UINT32_C(3611029619),
+      UINT8_C(190),
+      UINT32_C(2087866855) },
+    { UINT32_C(3633137044),
+      UINT8_C(206),
+      UINT32_C( 975142830) },
+    { UINT32_C(3701195429),
+      UINT8_C( 59),
+      UINT32_C(1041029362) },
+    { UINT32_C(1574265292),
+      UINT8_C( 54),
+      UINT32_C(2563871276) },
+    { UINT32_C( 464550963),
+      UINT8_C( 75),
+      UINT32_C(4217027774) },
+    { UINT32_C(3547716249),
+      UINT8_C(211),
+      UINT32_C( 709509214) }
+  };
+
+  for (size_t i = 0 ; i < (sizeof(test_vec) / sizeof(test_vec[0])) ; i++) {
+    uint32_t crc = test_vec[i].crc;
+    uint8_t v = test_vec[i].v;
+    uint32_t r = simde_mm_crc32_u8(crc, v);
+    munit_assert_uint32(r, ==, test_vec[i].r);
+  }
+
+  return 0;
+}
+
 SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_cmpestrs_8)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_cmpestrs_16)
@@ -901,6 +944,7 @@ SIMDE_TEST_FUNC_LIST_BEGIN
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_cmpistrs_16)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_cmpistrz_8)
   SIMDE_TEST_FUNC_LIST_ENTRY(mm_cmpistrz_16)
+  SIMDE_TEST_FUNC_LIST_ENTRY(mm_crc32_u8)
 SIMDE_TEST_FUNC_LIST_END
 
 #include <test/x86/test-x86-footer.h>


### PR DESCRIPTION
I went through https://create.stephan-brumme.com/crc32/#git1 and https://github.com/stbrumme/crc32/blob/master/Crc32Best.ino implementation again, and I noticed that it is taking a previouscrc and a bunch of values and returning new crc32, and we need the same except the polynomial is different and we have one value v instead of array of values(data) so I tried using that implementation in this PR, but the difference is that this implementation is different from IIG. Please review this and also suggest how should I write tests for this function as this is different from other functions and skel.c is also different now so I am a little confused.