### PR TITLE
Fix array sizes and native aliases

### DIFF
--- a/simde/arm/neon/ld1.h
+++ b/simde/arm/neon/ld1.h
@@ -213,7 +213,7 @@ simde_vld1q_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_f32
-  #define vld1_f32(a) simde_vld1_f32((a))
+  #define vld1q_f32(a) simde_vld1q_f32((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -231,9 +231,9 @@ simde_vld1q_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     return simde_float64x2_from_private(r_);
   #endif
 }
-#if defined(SIMDE_ARM_NEON_A64V_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
   #undef vld1_f64
-  #define vld1_f64(a) simde_vld1_f64((a))
+  #define vld1q_f64(a) simde_vld1q_f64((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -256,7 +256,7 @@ simde_vld1q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s8
-  #define vld1_s8(a) simde_vld1_s8((a))
+  #define vld1q_s8(a) simde_vld1q_s8((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -279,7 +279,7 @@ simde_vld1q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s16
-  #define vld1_s16(a) simde_vld1_s16((a))
+  #define vld1q_s16(a) simde_vld1q_s16((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -302,7 +302,7 @@ simde_vld1q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s32
-  #define vld1_s32(a) simde_vld1_s32((a))
+  #define vld1q_s32(a) simde_vld1q_s32((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -322,7 +322,7 @@ simde_vld1q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s64
-  #define vld1_s64(a) simde_vld1_s64((a))
+  #define vld1q_s64(a) simde_vld1q_s64((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -345,7 +345,7 @@ simde_vld1q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u8
-  #define vld1_u8(a) simde_vld1_u8((a))
+  #define vld1q_u8(a) simde_vld1q_u8((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -368,7 +368,7 @@ simde_vld1q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u16
-  #define vld1_u16(a) simde_vld1_u16((a))
+  #define vld1q_u16(a) simde_vld1q_u16((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -391,7 +391,7 @@ simde_vld1q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u32
-  #define vld1_u32(a) simde_vld1_u32((a))
+  #define vld1q_u32(a) simde_vld1q_u32((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -411,7 +411,7 @@ simde_vld1q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u64
-  #define vld1_u64(a) simde_vld1_u64((a))
+  #define vld1q_u64(a) simde_vld1q_u64((a))
 #endif
 
 SIMDE_END_DECLS_

--- a/simde/arm/neon/ld1.h
+++ b/simde/arm/neon/ld1.h
@@ -46,7 +46,7 @@ simde_vld1_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_f32
-  #define vld1_f32(a, b) simde_vld1_f32((a), (b))
+  #define vld1_f32(a) simde_vld1_f32((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -62,7 +62,7 @@ simde_vld1_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(1)]) {
 }
 #if defined(SIMDE_ARM_NEON_A64V_ENABLE_NATIVE_ALIASES)
   #undef vld1_f64
-  #define vld1_f64(a, b) simde_vld1_f64((a), (b))
+  #define vld1_f64(a) simde_vld1_f64((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -78,7 +78,7 @@ simde_vld1_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s8
-  #define vld1_s8(a, b) simde_vld1_s8((a), (b))
+  #define vld1_s8(a) simde_vld1_s8((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -94,7 +94,7 @@ simde_vld1_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s16
-  #define vld1_s16(a, b) simde_vld1_s16((a), (b))
+  #define vld1_s16(a) simde_vld1_s16((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -110,7 +110,7 @@ simde_vld1_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s32
-  #define vld1_s32(a, b) simde_vld1_s32((a), (b))
+  #define vld1_s32(a) simde_vld1_s32((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -126,7 +126,7 @@ simde_vld1_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(1)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s64
-  #define vld1_s64(a, b) simde_vld1_s64((a), (b))
+  #define vld1_s64(a) simde_vld1_s64((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -142,12 +142,12 @@ simde_vld1_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u8
-  #define vld1_u8(a, b) simde_vld1_u8((a), (b))
+  #define vld1_u8(a) simde_vld1_u8((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde_uint16x4_t
-simde_vld1_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
+simde_vld1_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld1_u16(ptr);
   #else
@@ -158,7 +158,7 @@ simde_vld1_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u16
-  #define vld1_u16(a, b) simde_vld1_u16((a), (b))
+  #define vld1_u16(a) simde_vld1_u16((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -174,7 +174,7 @@ simde_vld1_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u32
-  #define vld1_u32(a, b) simde_vld1_u32((a), (b))
+  #define vld1_u32(a) simde_vld1_u32((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -190,7 +190,7 @@ simde_vld1_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(1)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u64
-  #define vld1_u64(a, b) simde_vld1_u64((a), (b))
+  #define vld1_u64(a) simde_vld1_u64((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -213,7 +213,7 @@ simde_vld1q_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_f32
-  #define vld1_f32(a, b) simde_vld1_f32((a), (b))
+  #define vld1_f32(a) simde_vld1_f32((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -233,7 +233,7 @@ simde_vld1q_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
 }
 #if defined(SIMDE_ARM_NEON_A64V_ENABLE_NATIVE_ALIASES)
   #undef vld1_f64
-  #define vld1_f64(a, b) simde_vld1_f64((a), (b))
+  #define vld1_f64(a) simde_vld1_f64((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -256,7 +256,7 @@ simde_vld1q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s8
-  #define vld1_s8(a, b) simde_vld1_s8((a), (b))
+  #define vld1_s8(a) simde_vld1_s8((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -279,7 +279,7 @@ simde_vld1q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s16
-  #define vld1_s16(a, b) simde_vld1_s16((a), (b))
+  #define vld1_s16(a) simde_vld1_s16((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -302,7 +302,7 @@ simde_vld1q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s32
-  #define vld1_s32(a, b) simde_vld1_s32((a), (b))
+  #define vld1_s32(a) simde_vld1_s32((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -322,7 +322,7 @@ simde_vld1q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_s64
-  #define vld1_s64(a, b) simde_vld1_s64((a), (b))
+  #define vld1_s64(a) simde_vld1_s64((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -345,7 +345,7 @@ simde_vld1q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u8
-  #define vld1_u8(a, b) simde_vld1_u8((a), (b))
+  #define vld1_u8(a) simde_vld1_u8((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -368,7 +368,7 @@ simde_vld1q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u16
-  #define vld1_u16(a, b) simde_vld1_u16((a), (b))
+  #define vld1_u16(a) simde_vld1_u16((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -391,7 +391,7 @@ simde_vld1q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u32
-  #define vld1_u32(a, b) simde_vld1_u32((a), (b))
+  #define vld1_u32(a) simde_vld1_u32((a))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -411,7 +411,7 @@ simde_vld1q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vld1_u64
-  #define vld1_u64(a, b) simde_vld1_u64((a), (b))
+  #define vld1_u64(a) simde_vld1_u64((a))
 #endif
 
 SIMDE_END_DECLS_

--- a/simde/arm/neon/st1.h
+++ b/simde/arm/neon/st1.h
@@ -197,7 +197,7 @@ simde_vst1q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_float32x4_t va
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst1_f32
-  #define vst1_f32(a, b) simde_vst1_f32((a), (b))
+  #define vst1q_f32(a, b) simde_vst1q_f32((a), (b))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -212,7 +212,7 @@ simde_vst1q_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_float64x2_t va
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
   #undef vst1_f64
-  #define vst1_f64(a, b) simde_vst1_f64((a), (b))
+  #define vst1q_f64(a, b) simde_vst1q_f64((a), (b))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -227,7 +227,7 @@ simde_vst1q_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_int8x16_t val) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst1_s8
-  #define vst1_s8(a, b) simde_vst1_s8((a), (b))
+  #define vst1q_s8(a, b) simde_vst1q_s8((a), (b))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -242,7 +242,7 @@ simde_vst1q_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int16x8_t val) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst1_s16
-  #define vst1_s16(a, b) simde_vst1_s16((a), (b))
+  #define vst1q_s16(a, b) simde_vst1q_s16((a), (b))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -257,7 +257,7 @@ simde_vst1q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_int32x4_t val) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst1_s32
-  #define vst1_s32(a, b) simde_vst1_s32((a), (b))
+  #define vst1q_s32(a, b) simde_vst1q_s32((a), (b))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -272,7 +272,7 @@ simde_vst1q_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_int64x2_t val) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst1_s64
-  #define vst1_s64(a, b) simde_vst1_s64((a), (b))
+  #define vst1q_s64(a, b) simde_vst1q_s64((a), (b))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -287,7 +287,7 @@ simde_vst1q_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_uint8x16_t val) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst1_u8
-  #define vst1_u8(a, b) simde_vst1_u8((a), (b))
+  #define vst1q_u8(a, b) simde_vst1q_u8((a), (b))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -302,7 +302,7 @@ simde_vst1q_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint16x8_t val) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst1_u16
-  #define vst1_u16(a, b) simde_vst1_u16((a), (b))
+  #define vst1q_u16(a, b) simde_vst1q_u16((a), (b))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -317,7 +317,7 @@ simde_vst1q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_uint32x4_t val) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst1_u32
-  #define vst1_u32(a, b) simde_vst1_u32((a), (b))
+  #define vst1q_u32(a, b) simde_vst1q_u32((a), (b))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -332,7 +332,7 @@ simde_vst1q_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_uint64x2_t val) {
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
   #undef vst1_u64
-  #define vst1_u64(a, b) simde_vst1_u64((a), (b))
+  #define vst1q_u64(a, b) simde_vst1q_u64((a), (b))
 #endif
 
 SIMDE_END_DECLS_

--- a/simde/arm/neon/st1.h
+++ b/simde/arm/neon/st1.h
@@ -35,7 +35,7 @@ SIMDE_BEGIN_DECLS_
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_float32x2_t val) {
+simde_vst1_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_float32x2_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vst1_f32(ptr, val);
   #else
@@ -50,7 +50,7 @@ simde_vst1_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_float32x2_t val
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_float64x1_t val) {
+simde_vst1_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(1)], simde_float64x1_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vst1_f64(ptr, val);
   #else
@@ -65,7 +65,7 @@ simde_vst1_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_float64x1_t val
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_int8x8_t val) {
+simde_vst1_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int8x8_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1_s8(ptr, val);
   #else
@@ -80,7 +80,7 @@ simde_vst1_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_int8x8_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int16x4_t val) {
+simde_vst1_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_int16x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1_s16(ptr, val);
   #else
@@ -95,7 +95,7 @@ simde_vst1_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int16x4_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int32x2_t val) {
+simde_vst1_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_int32x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1_s32(ptr, val);
   #else
@@ -110,7 +110,7 @@ simde_vst1_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int32x2_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int64x1_t val) {
+simde_vst1_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(1)], simde_int64x1_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1_s64(ptr, val);
   #else
@@ -125,7 +125,7 @@ simde_vst1_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int64x1_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_uint8x8_t val) {
+simde_vst1_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint8x8_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1_u8(ptr, val);
   #else
@@ -140,7 +140,7 @@ simde_vst1_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_uint8x8_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint16x4_t val) {
+simde_vst1_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_uint16x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1_u16(ptr, val);
   #else
@@ -155,7 +155,7 @@ simde_vst1_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint16x4_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint32x2_t val) {
+simde_vst1_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_uint32x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1_u32(ptr, val);
   #else
@@ -170,7 +170,7 @@ simde_vst1_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint32x2_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint64x1_t val) {
+simde_vst1_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(1)], simde_uint64x1_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1_u64(ptr, val);
   #else
@@ -185,7 +185,7 @@ simde_vst1_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint64x1_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_float32x4_t val) {
+simde_vst1q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_float32x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1q_f32(ptr, val);
   #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
@@ -202,7 +202,7 @@ simde_vst1q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_float32x4_t va
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1q_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_float64x2_t val) {
+simde_vst1q_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_float64x2_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vst1q_f64(ptr, val);
   #else
@@ -247,7 +247,7 @@ simde_vst1q_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int16x8_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int32x4_t val) {
+simde_vst1q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_int32x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1q_s32(ptr, val);
   #else
@@ -262,7 +262,7 @@ simde_vst1q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int32x4_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1q_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int64x2_t val) {
+simde_vst1q_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_int64x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1q_s64(ptr, val);
   #else
@@ -307,7 +307,7 @@ simde_vst1q_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint16x8_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint32x4_t val) {
+simde_vst1q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_uint32x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1q_u32(ptr, val);
   #else
@@ -322,7 +322,7 @@ simde_vst1q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint32x4_t val) {
 
 SIMDE_FUNCTION_ATTRIBUTES
 void
-simde_vst1q_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint64x2_t val) {
+simde_vst1q_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_uint64x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vst1q_u64(ptr, val);
   #else


### PR DESCRIPTION
Hey, I noticed the array sizes and argument lists for the vld1 and vst1 intrinsics weren't quite matching up, so I rewrote some of them. 

Let me know if something's missing here, but I'm _pretty sure_ this should be right.