### PR TITLE
neon: int[0-9]+x[0-9]+x2 vector types and generated functions

### DIFF
--- a/simde/arm/neon/types.h
+++ b/simde/arm/neon/types.h
@@ -96,14 +96,42 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
   typedef float32x4_t simde_float32x4_t;
   typedef   float32_t   simde_float32_t;
 
+  typedef    int8x8x2_t    simde_int8x8x2_t;
+  typedef   int16x4x2_t   simde_int16x4x2_t;
+  typedef   int32x2x2_t   simde_int32x2x2_t;
+  typedef   int64x1x2_t   simde_int64x1x2_t;
+  typedef   uint8x8x2_t   simde_uint8x8x2_t;
+  typedef  uint16x4x2_t  simde_uint16x4x2_t;
+  typedef  uint32x2x2_t  simde_uint32x2x2_t;
+  typedef  uint64x1x2_t  simde_uint64x1x2_t;
+  typedef float32x2x2_t simde_float32x2x2_t;
+  
+  typedef   int8x16x2_t   simde_int8x16x2_t;
+  typedef   int16x8x2_t   simde_int16x8x2_t;
+  typedef   int32x4x2_t   simde_int32x4x2_t;
+  typedef   int64x2x2_t   simde_int64x2x2_t;
+  typedef  uint8x16x2_t  simde_uint8x16x2_t;
+  typedef  uint16x8x2_t  simde_uint16x8x2_t;
+  typedef  uint32x4x2_t  simde_uint32x4x2_t;
+  typedef  uint64x2x2_t  simde_uint64x2x2_t;
+  typedef float32x4x2_t simde_float32x4x2_t;
+  typedef   float32x2_t   simde_float32x2_t;
+
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     typedef float64x1_t simde_float64x1_t;
     typedef float64x2_t simde_float64x2_t;
     typedef   float64_t   simde_float64_t;
+
+    typedef float64x1x2_t simde_float64x1x2_t;
+    typedef float64x2x2_t simde_float64x2x2_t;
+    typedef   float64x2_t   simde_float64x2_t;
   #else
     #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1
     #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2
     #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
+
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1X2
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2X2
   #endif
 #elif defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
   #define SIMDE_ARM_NEON_NEED_PORTABLE_F32
@@ -201,6 +229,10 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
   #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
   #define SIMDE_ARM_NEON_NEED_PORTABLE_64BIT
   #define SIMDE_ARM_NEON_NEED_PORTABLE_128BIT
+
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_VX2
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1X2
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2X2
 #endif
 
 #if defined(SIMDE_ARM_NEON_NEED_PORTABLE_I8X8) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
@@ -272,29 +304,116 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
   typedef simde_float64 simde_float64_t;
 #endif
 
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_VX2)
+  typedef struct    simde_int8x8x2_t {
+    simde_int8x8_t val[2];
+  } simde_int8x8x2_t;
+  typedef struct   simde_int16x4x2_t {
+    simde_int16x4_t val[2];
+  } simde_int16x4x2_t;
+  typedef struct   simde_int32x2x2_t {
+    simde_int32x2_t val[2];
+  } simde_int32x2x2_t;
+  typedef struct   simde_int64x1x2_t {
+    simde_int64x1_t val[2];
+  } simde_int64x1x2_t;
+  typedef struct   simde_uint8x8x2_t {
+    simde_uint8x8_t val[2];
+  } simde_uint8x8x2_t;
+  typedef struct  simde_uint16x4x2_t {
+    simde_uint16x4_t val[2];
+  } simde_uint16x4x2_t;
+  typedef struct  simde_uint32x2x2_t {
+    simde_uint32x2_t val[2];
+  } simde_uint32x2x2_t;
+  typedef struct simde_float32x2x2_t {
+    simde_float32x2_t val[2];
+  } simde_float32x2x2_t;
+
+  typedef struct   simde_int8x16x2_t {
+    simde_int8x16_t val[2];
+  } simde_int8x16x2_t;
+  typedef struct   simde_int16x8x2_t {
+    simde_int16x8_t val[2];
+  } simde_int16x8x2_t;
+  typedef struct   simde_int32x4x2_t {
+    simde_int32x4_t val[2];
+  } simde_int32x4x2_t;
+  typedef struct   simde_int64x2x2_t {
+    simde_int64x2_t val[2];
+  } simde_int64x2x2_t;
+  typedef struct  simde_uint8x16x2_t {
+    simde_uint8x16_t val[2];
+  } simde_uint8x16x2_t;
+  typedef struct  simde_uint16x8x2_t {
+    simde_uint16x8_t val[2];
+  } simde_uint16x8x2_t;
+  typedef struct  simde_uint32x4x2_t {
+    simde_uint32x4_t val[2];
+  } simde_uint32x4x2_t;
+  typedef struct simde_float32x4x2_t {
+    simde_float32x4_t val[2];
+  } simde_float32x4x2_t;
+#endif
+
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_F64X1X2)
+  typedef struct   simde_float64x1x2_t {
+    simde_float64x1_t val[2];
+  } simde_float64x1x2_t;
+#endif
+
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_F64X2X2)
+typedef struct   simde_float64x2x2_t {
+  simde_float64x2_t val[2];
+} simde_float64x2x2_t;
+#endif
+
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
-  typedef simde_int8x8_t    int8x8_t;
-  typedef simde_int16x4_t   int16x4_t;
-  typedef simde_int32x2_t   int32x2_t;
-  typedef simde_int64x1_t   int64x1_t;
-  typedef simde_uint8x8_t   uint8x8_t;
-  typedef simde_uint16x4_t  uint16x4_t;
-  typedef simde_uint32x2_t  uint32x2_t;
-  typedef simde_uint64x1_t  uint64x1_t;
+  typedef    simde_int8x8_t    int8x8_t;
+  typedef   simde_int16x4_t   int16x4_t;
+  typedef   simde_int32x2_t   int32x2_t;
+  typedef   simde_int64x1_t   int64x1_t;
+  typedef   simde_uint8x8_t   uint8x8_t;
+  typedef  simde_uint16x4_t  uint16x4_t;
+  typedef  simde_uint32x2_t  uint32x2_t;
+  typedef  simde_uint64x1_t  uint64x1_t;
   typedef simde_float32x2_t float32x2_t;
-  typedef simde_int8x16_t   int8x16_t;
-  typedef simde_int16x8_t   int16x8_t;
-  typedef simde_int32x4_t   int32x4_t;
-  typedef simde_int64x2_t   int64x2_t;
-  typedef simde_uint8x16_t  uint8x16_t;
-  typedef simde_uint16x8_t  uint16x8_t;
-  typedef simde_uint32x4_t  uint32x4_t;
-  typedef simde_uint64x2_t  uint64x2_t;
+  typedef   simde_int8x16_t   int8x16_t;
+  typedef   simde_int16x8_t   int16x8_t;
+  typedef   simde_int32x4_t   int32x4_t;
+  typedef   simde_int64x2_t   int64x2_t;
+  typedef  simde_uint8x16_t  uint8x16_t;
+  typedef  simde_uint16x8_t  uint16x8_t;
+  typedef  simde_uint32x4_t  uint32x4_t;
+  typedef  simde_uint64x2_t  uint64x2_t;
   typedef simde_float32x4_t float32x4_t;
+
+  typedef    simde_int8x8x2_t    int8x8x2_t;
+  typedef   simde_int16x4x2_t   int16x4x2_t;
+  typedef   simde_int32x2x2_t   int32x2x2_t;
+  typedef   simde_int64x1x2_t   int64x1x2_t;
+  typedef   simde_uint8x8x2_t   uint8x8x2_t;
+  typedef  simde_uint16x4x2_t  uint16x4x2_t;
+  typedef  simde_uint32x2x2_t  uint32x2x2_t;
+  typedef  simde_uint64x1x2_t  uint64x1x2_t;
+  typedef simde_float32x2x2_t float32x2x2_t;
+  typedef   simde_int8x16x2_t   int8x16x2_t;
+  typedef   simde_int16x8x2_t   int16x8x2_t;
+  typedef   simde_int32x4x2_t   int32x4x2_t;
+  typedef   simde_int64x2x2_t   int64x2x2_t;
+  typedef  simde_uint8x16x2_t  uint8x16x2_t;
+  typedef  simde_uint16x8x2_t  uint16x8x2_t;
+  typedef  simde_uint32x4x2_t  uint32x4x2_t;
+  typedef  simde_uint64x2x2_t  uint64x2x2_t;
+  typedef simde_float32x4x2_t float32x4x2_t;
+
 #endif
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
-  typedef simde_float64x1_t float64x1_t;
-  typedef simde_float64x2_t float64x2_t;
+  typedef simde_float64x1_t   float64x1_t;
+  typedef simde_float64x2_t   float64x2_t;
+
+  typedef  simde_uint64x1x2_t  uint64x1x2_t;
+  typedef simde_float64x2x2_t float64x2x2_t;
 #endif
 
 #define SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(T) \

--- a/simde/arm/neon/types.h
+++ b/simde/arm/neon/types.h
@@ -115,7 +115,6 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
   typedef  uint32x4x2_t  simde_uint32x4x2_t;
   typedef  uint64x2x2_t  simde_uint64x2x2_t;
   typedef float32x4x2_t simde_float32x4x2_t;
-  typedef   float32x2_t   simde_float32x2_t;
 
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     typedef float64x1_t simde_float64x1_t;

--- a/simde/arm/neon/types.h
+++ b/simde/arm/neon/types.h
@@ -105,7 +105,7 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
   typedef  uint32x2x2_t  simde_uint32x2x2_t;
   typedef  uint64x1x2_t  simde_uint64x1x2_t;
   typedef float32x2x2_t simde_float32x2x2_t;
-  
+
   typedef   int8x16x2_t   simde_int8x16x2_t;
   typedef   int16x8x2_t   simde_int16x8x2_t;
   typedef   int32x4x2_t   simde_int32x4x2_t;
@@ -136,6 +136,10 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
 #elif defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
   #define SIMDE_ARM_NEON_NEED_PORTABLE_F32
   #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
+
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_VX2
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1X2
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2X2
 
   #if defined(SIMDE_X86_MMX_NATIVE)
     typedef __m64    simde_int8x8_t;
@@ -193,6 +197,11 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
   #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
 
   #define SIMDE_ARM_NEON_NEED_PORTABLE_64BIT
+
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1X2
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2X2
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_VX2
+
   typedef v128_t   simde_int8x16_t;
   typedef v128_t   simde_int16x8_t;
   typedef v128_t   simde_int32x4_t;
@@ -208,6 +217,9 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
   #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
 
   #define SIMDE_ARM_NEON_NEED_PORTABLE_64BIT
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1X2
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2X2
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_VX2
 
   typedef SIMDE_POWER_ALTIVEC_VECTOR(signed char)          simde_int8x16_t;
   typedef SIMDE_POWER_ALTIVEC_VECTOR(signed short)         simde_int16x8_t;
@@ -326,6 +338,9 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
   typedef struct  simde_uint32x2x2_t {
     simde_uint32x2_t val[2];
   } simde_uint32x2x2_t;
+  typedef struct  simde_uint64x1x2_t {
+    simde_uint64x1_t val[2];
+  } simde_uint64x1x2_t;
   typedef struct simde_float32x2x2_t {
     simde_float32x2_t val[2];
   } simde_float32x2x2_t;
@@ -351,6 +366,9 @@ SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
   typedef struct  simde_uint32x4x2_t {
     simde_uint32x4_t val[2];
   } simde_uint32x4x2_t;
+  typedef struct  simde_uint64x2x2_t {
+    simde_uint64x2_t val[2];
+  } simde_uint64x2x2_t;
   typedef struct simde_float32x4x2_t {
     simde_float32x4_t val[2];
   } simde_float32x4x2_t;

--- a/test/arm/neon/test-neon.h
+++ b/test/arm/neon/test-neon.h
@@ -60,6 +60,7 @@
     return simde_assert_equal_v##symbol_identifier##_(sizeof(a_) / sizeof(ET), HEDLEY_REINTERPRET_CAST(SET*, a_), HEDLEY_REINTERPRET_CAST(SET*, b_), slop, filename, line, astr, bstr); \
   }
 
+
 HEDLEY_DIAGNOSTIC_PUSH
 SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_
 SIMDE_TEST_ARM_NEON_GENERATE_INT_TYPE_FUNCS_(     int8x8_t,   int8_t,  8,  ,  i8,  s8)
@@ -83,6 +84,126 @@ SIMDE_TEST_ARM_NEON_GENERATE_INT_TYPE_FUNCS_(   uint32x4_t,  uint32_t,  4, q, u3
 SIMDE_TEST_ARM_NEON_GENERATE_INT_TYPE_FUNCS_(   uint64x2_t,  uint64_t,  2, q, u64, u64)
 SIMDE_TEST_ARM_NEON_GENERATE_FLOAT_TYPE_FUNCS_(float32x4_t, simde_float32_t, simde_float32, 4, q, f32)
 SIMDE_TEST_ARM_NEON_GENERATE_FLOAT_TYPE_FUNCS_(float64x2_t, simde_float64_t, simde_float64, 2, q, f64)
+HEDLEY_DIAGNOSTIC_POP
+
+#define SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(NT, ET, element_count, modifier, symbol_identifier, neon_identifier) \
+  static simde_##NT \
+  simde_test_arm_neon_random_##symbol_identifier##x##element_count##x2(void) { \
+    simde_##NT v; \
+    simde_test_codegen_random_memory(sizeof(v), HEDLEY_REINTERPRET_CAST(uint8_t*, &v)); \
+    return v; \
+  } \
+ \
+  static void \
+  simde_test_arm_neon_write_##symbol_identifier##x##element_count##x2(int indent, simde_##NT value, SimdeTestVecPos pos) { \
+    simde_test_codegen_write_indent(indent); \
+    fputs("  {\n", stdout); \
+    ET value0_[sizeof(value) / sizeof(ET) / 2]; \
+    ET value1_[sizeof(value) / sizeof(ET) / 2]; \
+ \
+    simde_vst1##modifier##_##neon_identifier(value0_, value.val[0]); \
+    simde_vst1##modifier##_##neon_identifier(value1_, value.val[1]); \
+ \
+    simde_test_codegen_write_v##symbol_identifier(indent+2, sizeof(value0_) / sizeof(ET), value0_, SIMDE_TEST_VEC_POS_MIDDLE); \
+    simde_test_codegen_write_v##symbol_identifier(indent+2, sizeof(value1_) / sizeof(ET), value1_, SIMDE_TEST_VEC_POS_MIDDLE); \
+    if (pos == SIMDE_TEST_VEC_POS_LAST) { \
+      simde_test_codegen_write_indent(indent); \
+      fputs("  },\n", stdout); \
+      simde_test_codegen_write_indent(indent); \
+      fputs("},\n", stdout); \
+    } else { \
+      fputs("  },\n", stdout); \
+    } \
+ \
+  } \
+ \
+  static int \
+  simde_test_arm_neon_assert_equal_##symbol_identifier##x##element_count##x2_(simde_##NT a, simde_##NT b, \
+      const char* filename, int line, const char* astr, const char* bstr) { \
+    ET a0_[sizeof(a.val[0]) / sizeof(ET)], b0_[sizeof(b.val[0]) / sizeof(ET)]; \
+    ET a1_[sizeof(a.val[1]) / sizeof(ET)], b1_[sizeof(b.val[1]) / sizeof(ET)]; \
+ \
+    simde_vst1##modifier##_##neon_identifier(a0_, a.val[0]); \
+    simde_vst1##modifier##_##neon_identifier(b0_, b.val[0]); \
+    simde_vst1##modifier##_##neon_identifier(a1_, a.val[1]); \
+    simde_vst1##modifier##_##neon_identifier(b1_, b.val[1]); \
+ \
+    return simde_assert_equal_v##symbol_identifier##_(sizeof(a0_) / sizeof(a0_[0]), a0_, b0_, filename, line, astr, bstr) \
+      && simde_assert_equal_v##symbol_identifier##_(sizeof(a1_) / sizeof(a1_[0]), a1_, b1_, filename, line, astr, bstr); \
+  }
+
+#define SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_FLOAT_TYPE_FUNCS_(NT, ET, SET, element_count, modifier, symbol_identifier) \
+  static simde_##NT \
+  simde_test_arm_neon_random_##symbol_identifier##x##element_count##x2(ET min, ET max) { \
+    SET v0[sizeof(simde_##NT) / sizeof(ET) / 2]; \
+    SET v1[sizeof(simde_##NT) / sizeof(ET) / 2]; \
+    simde_test_codegen_random_v##symbol_identifier(sizeof(v0) / sizeof(v0[0]), v0, HEDLEY_STATIC_CAST(SET, min), HEDLEY_STATIC_CAST(SET, max)); \
+    simde_test_codegen_random_v##symbol_identifier(sizeof(v1) / sizeof(v1[0]), v1, HEDLEY_STATIC_CAST(SET, min), HEDLEY_STATIC_CAST(SET, max)); \
+    simde_##NT r; \
+    r.val[0] = simde_vld1##modifier##_##symbol_identifier(HEDLEY_REINTERPRET_CAST(ET*, v0)); \
+    r.val[1] = simde_vld1##modifier##_##symbol_identifier(HEDLEY_REINTERPRET_CAST(ET*, v1)); \
+    return r; \
+  } \
+ \
+  static void \
+  simde_test_arm_neon_write_##symbol_identifier##x##element_count##x2(int indent, simde_##NT value, SimdeTestVecPos pos) { \
+    simde_test_codegen_write_indent(indent); \
+    fputs("  {\n", stdout); \
+ \
+    ET value0_[sizeof(value) / sizeof(ET) / 2]; \
+    ET value1_[sizeof(value) / sizeof(ET) / 2]; \
+    simde_vst1##modifier##_##symbol_identifier(value0_, value.val[0]); \
+    simde_vst1##modifier##_##symbol_identifier(value1_, value.val[1]); \
+    simde_test_codegen_write_v##symbol_identifier(indent + 2, sizeof(value0_) / sizeof(value0_[0]), value0_, SIMDE_TEST_VEC_POS_MIDDLE); \
+    simde_test_codegen_write_v##symbol_identifier(indent + 2, sizeof(value1_) / sizeof(value1_[0]), value1_, SIMDE_TEST_VEC_POS_MIDDLE); \
+    if (pos == SIMDE_TEST_VEC_POS_LAST) { \
+      simde_test_codegen_write_indent(indent); \
+      fputs("  },\n", stdout); \
+      simde_test_codegen_write_indent(indent); \
+      fputs("},\n", stdout); \
+    } else { \
+      fputs("  },\n", stdout); \
+    } \
+  } \
+ \
+  static int \
+  simde_test_arm_neon_assert_equal_##symbol_identifier##x##element_count##x2_(simde_##NT a, simde_##NT b, ET slop, \
+     const char* filename, int line, const char* astr, const char* bstr) { \
+    SET a0_[sizeof(a) / sizeof(ET)], b0_[sizeof(b) / sizeof(ET)]; \
+    SET a1_[sizeof(a) / sizeof(ET)], b1_[sizeof(b) / sizeof(ET)]; \
+ \
+    simde_vst1##modifier##_##symbol_identifier(a0_, a.val[0]); \
+    simde_vst1##modifier##_##symbol_identifier(b0_, b.val[0]);       \
+    simde_vst1##modifier##_##symbol_identifier(a1_, a.val[1]); \
+    simde_vst1##modifier##_##symbol_identifier(b1_, b.val[1]); \
+ \
+    return simde_assert_equal_v##symbol_identifier##_(sizeof(a0_) / sizeof(ET), HEDLEY_REINTERPRET_CAST(SET*, a0_), HEDLEY_REINTERPRET_CAST(SET*, b0_), slop, filename, line, astr, bstr) && \
+      simde_assert_equal_v##symbol_identifier##_(sizeof(a1_) / sizeof(ET), HEDLEY_REINTERPRET_CAST(SET*, a1_), HEDLEY_REINTERPRET_CAST(SET*, b1_), slop, filename, line, astr, bstr); \
+  }
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(     int8x8x2_t,   int8_t,  8,  ,  i8,  s8)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(    int16x4x2_t,  int16_t,  4,  , i16, s16)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(    int32x2x2_t,  int32_t,  2,  , i32, s32)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(    int64x1x2_t,  int64_t,  1,  , i64, s64)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(    uint8x8x2_t,  uint8_t,  8,  ,  u8,  u8)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(   uint16x4x2_t, uint16_t,  4,  , u16, u16)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(   uint32x2x2_t, uint32_t,  2,  , u32, u32)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(   uint64x1x2_t, uint64_t,  1,  , u64, u64)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_FLOAT_TYPE_FUNCS_(float32x2x2_t, simde_float32_t, simde_float32, 2, , f32)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_FLOAT_TYPE_FUNCS_(float64x1x2_t, simde_float64_t, simde_float64, 1, , f64)
+
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(    int8x16x2_t,   int8_t, 16, q,  i8,  s8)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(    int16x8x2_t,  int16_t,  8, q, i16, s16)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(    int32x4x2_t,  int32_t,  4, q, i32, s32)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(    int64x2x2_t,  int64_t,  2, q, i64, s64)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(   uint8x16x2_t,  uint8_t, 16, q,  u8,  u8)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(   uint16x8x2_t,  uint16_t,  8, q, u16, u16)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(   uint32x4x2_t,  uint32_t,  4, q, u32, u32)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_INT_TYPE_FUNCS_(   uint64x2x2_t,  uint64_t,  2, q, u64, u64)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_FLOAT_TYPE_FUNCS_(float32x4x2_t, simde_float32_t, simde_float32, 4, q, f32)
+SIMDE_TEST_ARM_NEON_GENERATE_X2_VECTOR_FLOAT_TYPE_FUNCS_(float64x2x2_t, simde_float64_t, simde_float64, 2, q, f64)
 HEDLEY_DIAGNOSTIC_POP
 
 #define simde_test_arm_neon_assert_equal_i8x8(a, b)   do { if (simde_test_arm_neon_assert_equal_i8x8_(a, b, __FILE__, __LINE__, #a, #b)) { return 1; } } while (0)


### PR DESCRIPTION
Hello,

Here's the code I came up with for the x2 vector structs. 

Let me know if there's anything wrong with it. 

[One thing that just writing this, I realize I might not have done is wire up the assert_equal function properly, but I'll look into that in a bit.] (I'd normally test this a bit more rigorously, but I didn't see an easy way to even use the function in the testing at all, so I just did two compares, as opposed to having the single function do both for me.) 

An example of the code generated by this can be see in the PR I'm about to submit for zip.

(CC @ngzhian @tlively)