### PR TITLE
sse4.1: add NEON and AltiVec translations of *blend*; correct PPC versions globally

### DIFF
--- a/simde/arm/neon/add.h
+++ b/simde/arm/neon/add.h
@@ -364,7 +364,7 @@ simde_vaddq_f64(simde_float64x2_t a, simde_float64x2_t b) {
     return vaddq_f64(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_add_pd(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_add(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_f64x2_add(a, b);
@@ -500,7 +500,7 @@ simde_vaddq_s64(simde_int64x2_t a, simde_int64x2_t b) {
     return vaddq_s64(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_add_epi64(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_add(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i64x2_add(a, b);
@@ -622,7 +622,7 @@ simde_uint64x2_t
 simde_vaddq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vaddq_u64(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     return vec_add(a, b);
   #else
     simde_uint64x2_private

--- a/simde/arm/neon/and.h
+++ b/simde/arm/neon/and.h
@@ -383,7 +383,7 @@ simde_vandq_s64(simde_int64x2_t a, simde_int64x2_t b) {
     return vandq_s64(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_and_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_and(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_and(a, b);
@@ -519,7 +519,7 @@ simde_vandq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
     return vandq_u64(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_and_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_and(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_and(a, b);

--- a/simde/arm/neon/dup_n.h
+++ b/simde/arm/neon/dup_n.h
@@ -293,7 +293,7 @@ simde_vdupq_n_f64(double value) {
     return _mm_set1_pd(value);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_f64x2_splat(value);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     (void) value;
     return vec_splats(value);
   #else
@@ -402,7 +402,7 @@ simde_vdupq_n_s64(int64_t value) {
     return _mm_set1_epi64x(value);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i64x2_splat(value);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_splats(HEDLEY_STATIC_CAST(signed long long, value));
   #else
     simde_int64x2_private r_;
@@ -510,7 +510,7 @@ simde_vdupq_n_u64(uint64_t value) {
     return _mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, value));
   #elif defined (SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i64x2_splat(HEDLEY_STATIC_CAST(int64_t, value));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_splats(HEDLEY_STATIC_CAST(unsigned long long, value));
   #else
     simde_uint64x2_private r_;

--- a/simde/arm/neon/eor.h
+++ b/simde/arm/neon/eor.h
@@ -383,7 +383,7 @@ simde_veorq_s64(simde_int64x2_t a, simde_int64x2_t b) {
     return veorq_s64(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_xor_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_xor(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_xor(a, b);
@@ -519,7 +519,7 @@ simde_veorq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
     return veorq_u64(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_xor_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_xor(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_xor(a, b);

--- a/simde/arm/neon/mla.h
+++ b/simde/arm/neon/mla.h
@@ -314,7 +314,7 @@ simde_vmlaq_f64(simde_float64x2_t a, simde_float64x2_t b, simde_float64x2_t c) {
     return _mm_fmadd_pd(b, c, a);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_add_pd(_mm_mul_pd(b, c), a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_madd(b, c, a);
   #else
     simde_float64x2_private

--- a/simde/arm/neon/orr.h
+++ b/simde/arm/neon/orr.h
@@ -383,7 +383,7 @@ simde_vorrq_s64(simde_int64x2_t a, simde_int64x2_t b) {
     return vorrq_s64(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_or_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_or(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_or(a, b);
@@ -519,7 +519,7 @@ simde_vorrq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
     return vorrq_u64(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_or_si128(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_or(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_v128_or(a, b);

--- a/simde/arm/neon/shl.h
+++ b/simde/arm/neon/shl.h
@@ -555,7 +555,7 @@ simde_vshlq_s64 (const simde_int64x2_t a, const simde_int64x2_t b) {
     return _mm_blendv_epi8(_mm_sllv_epi64(a, b_abs),
                            _mm_xor_si128(_mm_srlv_epi64(_mm_xor_si128(a, maska), b_abs), maska),
                            _mm_cmpgt_epi64(zero, _mm_slli_epi64(b, 56)));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     vector signed long long a_shl, a_shr;
     vector unsigned long long b_abs, b_max;
     vector bool long long b_mask;
@@ -740,7 +740,7 @@ simde_vshlq_u64 (const simde_uint64x2_t a, const simde_int64x2_t b) {
     return _mm_blendv_epi8(_mm_sllv_epi64(a, b_abs),
                            _mm_srlv_epi64(a, b_abs),
                            _mm_cmpgt_epi64(_mm_setzero_si128(), _mm_slli_epi64(b, 56)));
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     vector unsigned long long b_abs;
     vector bool long long b_mask;
     b_abs = vec_and(HEDLEY_REINTERPRET_CAST(vector unsigned long long,

--- a/simde/arm/neon/shl.h
+++ b/simde/arm/neon/shl.h
@@ -414,7 +414,7 @@ simde_vshlq_s8 (const simde_int8x16_t a, const simde_int8x16_t b) {
     a_shl = vec_and(vec_sl(a, b_abs), vec_cmple(b_abs, b_max));
     a_shr = vec_sra(a, vec_min(b_abs, b_max));
     b_mask = vec_cmplt(b, vec_splat_s8(0));
-    return vec_or(vec_andc(a_shl, b_mask), vec_and(a_shr, b_mask));
+    return vec_sel(a_shl, a_shr, b_mask);
   #else
     simde_int8x16_private
       r_,
@@ -467,7 +467,7 @@ simde_vshlq_s16 (const simde_int16x8_t a, const simde_int16x8_t b) {
     a_shl = vec_and(vec_sl(a, b_abs), vec_cmple(b_abs, b_max));
     a_shr = vec_sra(a, vec_min(b_abs, b_max));
     b_mask = vec_cmplt(vec_sl(b, vec_splat_u16(8)), vec_splat_s16(0));
-    return vec_or(vec_andc(a_shl, b_mask), vec_and(a_shr, b_mask));
+    return vec_sel(a_shl, a_shr, b_mask);
   #else
     simde_int16x8_private
       r_,
@@ -513,7 +513,7 @@ simde_vshlq_s32 (const simde_int32x4_t a, const simde_int32x4_t b) {
     a_shr = vec_sra(a, vec_min(b_abs, b_max));
     b_mask = vec_cmplt(vec_sl(b, vec_splats(HEDLEY_STATIC_CAST(unsigned int, 24))),
                        vec_splat_s32(0));
-    return vec_or(vec_andc(a_shl, b_mask), vec_and(a_shr, b_mask));
+    return vec_sel(a_shl, a_shr, b_mask);
   #else
     simde_int32x4_private
       r_,
@@ -567,7 +567,7 @@ simde_vshlq_s64 (const simde_int64x2_t a, const simde_int64x2_t b) {
     a_shr = vec_sra(a, vec_min(b_abs, b_max));
     b_mask = vec_cmplt(vec_sl(b, vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 56))),
                        vec_splats(HEDLEY_STATIC_CAST(signed long long, 0)));
-    return vec_or(vec_andc(a_shl, b_mask), vec_and(a_shr, b_mask));
+    return vec_sel(a_shl, a_shr, b_mask);
   #else
     simde_int64x2_private
       r_,
@@ -608,8 +608,7 @@ simde_vshlq_u8 (const simde_uint8x16_t a, const simde_int8x16_t b) {
     vector bool char b_mask;
     b_abs = HEDLEY_REINTERPRET_CAST(vector unsigned char, vec_abs(b));
     b_mask = vec_cmplt(b, vec_splat_s8(0));
-    return vec_and(vec_or(vec_andc(vec_sl(a, b_abs), b_mask),
-                          vec_and (vec_sr(a, b_abs), b_mask)),
+    return vec_and(vec_sel(vec_sl(a, b_abs), vec_sr(a, b_abs), b_mask),
                    vec_cmplt(b_abs, vec_splat_u8(8)));
   #else
     simde_uint8x16_private
@@ -659,8 +658,7 @@ simde_vshlq_u16 (const simde_uint16x8_t a, const simde_int16x8_t b) {
                                             vec_abs(HEDLEY_REINTERPRET_CAST(vector signed char, b))),
                     vec_splats(HEDLEY_STATIC_CAST(unsigned short, 0xFF)));
     b_mask = vec_cmplt(vec_sl(b, vec_splat_u16(8)), vec_splat_s16(0));
-    return vec_and(vec_or(vec_andc(vec_sl(a, b_abs), b_mask),
-                          vec_and (vec_sr(a, b_abs), b_mask)),
+    return vec_and(vec_sel(vec_sl(a, b_abs), vec_sr(a, b_abs), b_mask),
                    vec_cmple(b_abs, vec_splat_u16(15)));
   #else
     simde_uint16x8_private
@@ -702,8 +700,7 @@ simde_vshlq_u32 (const simde_uint32x4_t a, const simde_int32x4_t b) {
                                             vec_abs(HEDLEY_REINTERPRET_CAST(vector signed char, b))),
                     vec_splats(HEDLEY_STATIC_CAST(unsigned int, 0xFF)));
     b_mask = vec_cmplt(vec_sl(b, vec_splats(HEDLEY_STATIC_CAST(unsigned int, 24))), vec_splat_s32(0));
-    return vec_and(vec_or(vec_andc(vec_sl(a, b_abs), b_mask),
-                          vec_and (vec_sr(a, b_abs), b_mask)),
+    return vec_and(vec_sel(vec_sl(a, b_abs), vec_sr(a, b_abs), b_mask),
                    vec_cmplt(b_abs, vec_splats(HEDLEY_STATIC_CAST(unsigned int, 32))));
   #else
     simde_uint32x4_private
@@ -751,8 +748,7 @@ simde_vshlq_u64 (const simde_uint64x2_t a, const simde_int64x2_t b) {
                     vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 0xFF)));
     b_mask = vec_cmplt(vec_sl(b, vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 56))),
                        vec_splats(HEDLEY_STATIC_CAST(signed long long, 0)));
-    return vec_and(vec_or(vec_andc(vec_sl(a, b_abs), b_mask),
-                          vec_and(vec_sr(a, b_abs), b_mask)),
+    return vec_and(vec_sel(vec_sl(a, b_abs), vec_sr(a, b_abs), b_mask),
                    vec_cmplt(b_abs, vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 64))));
   #else
     simde_uint64x2_private

--- a/simde/arm/neon/shl_n.h
+++ b/simde/arm/neon/shl_n.h
@@ -400,7 +400,7 @@ simde_vshlq_n_s64 (const simde_int64x2_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshlq_n_s64(a, n) vshlq_n_s64((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
   #define simde_vshlq_n_s64(a, n) vec_sl((a), vec_splats(HEDLEY_STATIC_CAST(unsigned long long, (n))))
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -540,7 +540,7 @@ simde_vshlq_n_u64 (const simde_uint64x2_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshlq_n_u64(a, n) vshlq_n_u64((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
   #define simde_vshlq_n_u64(a, n) vec_sl((a), vec_splats(HEDLEY_STATIC_CAST(unsigned long long, (n))));
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/shr_n.h
+++ b/simde/arm/neon/shr_n.h
@@ -429,7 +429,7 @@ simde_vshrq_n_s64 (const simde_int64x2_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshrq_n_s64(a, n) vshrq_n_s64((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
   #define simde_vshrq_n_s64(a, n) \
     vec_sra((a), vec_splats(HEDLEY_STATIC_CAST(unsigned long long, ((n) == 64) ? 63 : (n))))
 #endif
@@ -589,7 +589,7 @@ simde_vshrq_n_u64 (const simde_uint64x2_t a, const int n)
 }
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   #define simde_vshrq_n_u64(a, n) vshrq_n_u64((a), (n))
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
   #define simde_vshrq_n_u64(a, n) \
     (((n) == 64) ? vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 0)) : vec_sr((a), vec_splats(HEDLEY_STATIC_CAST(unsigned long long, (n)))))
 #endif

--- a/simde/arm/neon/sub.h
+++ b/simde/arm/neon/sub.h
@@ -370,7 +370,7 @@ simde_vsubq_f64(simde_float64x2_t a, simde_float64x2_t b) {
     return vsubq_f64(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_sub_pd(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_sub(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_f64x2_sub(a, b);
@@ -506,7 +506,7 @@ simde_vsubq_s64(simde_int64x2_t a, simde_int64x2_t b) {
     return vsubq_s64(a, b);
   #elif defined(SIMDE_X86_SSE2_NATIVE)
     return _mm_sub_epi64(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_sub(a, b);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     return wasm_i64x2_sub(a, b);
@@ -628,7 +628,7 @@ simde_uint64x2_t
 simde_vsubq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vsubq_u64(a, b);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     return vec_sub(a, b);
   #else
     simde_uint64x2_private

--- a/simde/x86/avx.h
+++ b/simde/x86/avx.h
@@ -1354,6 +1354,11 @@ simde_mm256_blend_ps (simde__m256 a, simde__m256 b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX_NATIVE)
 #  define simde_mm256_blend_ps(a, b, imm8) _mm256_blend_ps(a, b, imm8)
+#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#  define simde_mm256_blend_ps(a, b, imm8) \
+      simde_mm256_set_m128( \
+          simde_mm_blend_ps(simde_mm256_extractf128_ps(a, 1), simde_mm256_extractf128_ps(b, 1), (imm8) >> 4), \
+          simde_mm_blend_ps(simde_mm256_extractf128_ps(a, 0), simde_mm256_extractf128_ps(b, 0), (imm8) & 0x0F))
 #endif
 #if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
 #  define _mm256_blend_ps(a, b, imm8) simde_mm256_blend_ps(a, b, imm8)
@@ -1376,6 +1381,11 @@ simde_mm256_blend_pd (simde__m256d a, simde__m256d b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX_NATIVE)
 #  define simde_mm256_blend_pd(a, b, imm8) _mm256_blend_pd(a, b, imm8)
+#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#  define simde_mm256_blend_pd(a, b, imm8) \
+      simde_mm256_set_m128d( \
+          simde_mm_blend_pd(simde_mm256_extractf128_pd(a, 1), simde_mm256_extractf128_pd(b, 1), (imm8) >> 2), \
+          simde_mm_blend_pd(simde_mm256_extractf128_pd(a, 0), simde_mm256_extractf128_pd(b, 0), (imm8) & 3))
 #endif
 #if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
 #  define _mm256_blend_pd(a, b, imm8) simde_mm256_blend_pd(a, b, imm8)
@@ -1393,7 +1403,7 @@ simde_mm256_blendv_ps (simde__m256 a, simde__m256 b, simde__m256 mask) {
     b_ = simde__m256_to_private(b),
     mask_ = simde__m256_to_private(mask);
 
-#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#if defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
   r_.m128[0] = simde_mm_blendv_ps(a_.m128[0], b_.m128[0], mask_.m128[0]);
   r_.m128[1] = simde_mm_blendv_ps(a_.m128[1], b_.m128[1], mask_.m128[1]);
 #else
@@ -1422,7 +1432,7 @@ simde_mm256_blendv_pd (simde__m256d a, simde__m256d b, simde__m256d mask) {
     b_ = simde__m256d_to_private(b),
     mask_ = simde__m256d_to_private(mask);
 
-#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#if defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
   r_.m128d[0] = simde_mm_blendv_pd(a_.m128d[0], b_.m128d[0], mask_.m128d[0]);
   r_.m128d[1] = simde_mm_blendv_pd(a_.m128d[1], b_.m128d[1], mask_.m128d[1]);
 #else

--- a/simde/x86/avx2.h
+++ b/simde/x86/avx2.h
@@ -521,6 +521,9 @@ simde_mm_blend_epi32(simde__m128i a, simde__m128i b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm_blend_epi32(a, b, imm8) _mm_blend_epi32(a, b, imm8)
+#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#  define simde_mm_blend_epi32(a, b, imm8) \
+  simde_mm_castps_si128(simde_mm_blend_ps(simde_mm_castsi128_ps(a), simde_mm_castsi128_ps(b), (imm8)))
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
   #undef _mm_blend_epi32
@@ -545,6 +548,11 @@ simde_mm256_blend_epi16(simde__m256i a, simde__m256i b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_blend_epi16(a, b, imm8) _mm256_blend_epi16(a, b, imm8)
+#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#  define simde_mm256_blend_epi16(a, b, imm8) \
+      simde_mm256_set_m128i( \
+          simde_mm_blend_epi16(simde_mm256_extracti128_si256(a, 1), simde_mm256_extracti128_si256(b, 1), (imm8)), \
+          simde_mm_blend_epi16(simde_mm256_extracti128_si256(a, 0), simde_mm256_extracti128_si256(b, 0), (imm8)))
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
   #undef _mm256_blend_epi16
@@ -570,6 +578,11 @@ simde_mm256_blend_epi32(simde__m256i a, simde__m256i b, const int imm8)
 }
 #if defined(SIMDE_X86_AVX2_NATIVE)
 #  define simde_mm256_blend_epi32(a, b, imm8) _mm256_blend_epi32(a, b, imm8)
+#elif defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#  define simde_mm256_blend_epi32(a, b, imm8) \
+      simde_mm256_set_m128i( \
+          simde_mm_blend_epi32(simde_mm256_extracti128_si256(a, 1), simde_mm256_extracti128_si256(b, 1), (imm8) >> 4), \
+          simde_mm_blend_epi32(simde_mm256_extracti128_si256(a, 0), simde_mm256_extracti128_si256(b, 0), (imm8) & 0x0F))
 #endif
 #if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
   #undef _mm256_blend_epi32
@@ -589,7 +602,7 @@ simde_mm256_blendv_epi8(simde__m256i a, simde__m256i b, simde__m256i mask) {
     b_ = simde__m256i_to_private(b),
     mask_ = simde__m256i_to_private(mask);
 
-#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#if defined(SIMDE_X86_SSE4_1_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
   r_.m128i_private[0] = simde__m128i_to_private(simde_mm_blendv_epi8(simde__m128i_from_private(a_.m128i_private[0]), simde__m128i_from_private(b_.m128i_private[0]), simde__m128i_from_private(mask_.m128i_private[0])));
   r_.m128i_private[1] = simde__m128i_to_private(simde_mm_blendv_epi8(simde__m128i_from_private(a_.m128i_private[1]), simde__m128i_from_private(b_.m128i_private[1]), simde__m128i_from_private(mask_.m128i_private[1])));
 #else

--- a/simde/x86/fma.h
+++ b/simde/x86/fma.h
@@ -42,7 +42,7 @@ simde__m128d
 simde_mm_fmadd_pd (simde__m128d a, simde__m128d b, simde__m128d c) {
   #if defined(SIMDE_X86_FMA_NATIVE)
     return _mm_fmadd_pd(a, b, c);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     simde__m128d_private
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b),

--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -177,7 +177,9 @@ simde__m128_to_private(simde__m128 v) {
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector unsigned int, altivec, u32)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector unsigned long long, altivec, u64)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector float, altivec, f32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector double, altivec, f64)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector double, altivec, f64)
+  #endif
 #endif /* defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) */
 
 enum {

--- a/simde/x86/sse.h
+++ b/simde/x86/sse.h
@@ -167,6 +167,19 @@ simde__m128_to_private(simde__m128 v) {
   #endif
 #endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
 
+#if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector signed char, altivec, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector signed short, altivec, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector signed int, altivec, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector signed long long, altivec, i64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector unsigned char, altivec, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector unsigned short, altivec, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector unsigned int, altivec, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector unsigned long long, altivec, u64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector float, altivec, f32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, vector double, altivec, f64)
+#endif /* defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) */
+
 enum {
 #if defined(SIMDE_X86_SSE_NATIVE)
   SIMDE_MM_ROUND_NEAREST     = _MM_ROUND_NEAREST,

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -111,7 +111,7 @@ typedef union {
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)       altivec_u16;
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32;
   #if defined(__UINT_FAST32_TYPE__)
-  SIMDE_ALIGN(16) vector __UINT_FAST32_TYPE__ altivec_u32f;
+  SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
   #else
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32f;
   #endif
@@ -186,7 +186,7 @@ typedef union {
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)       altivec_u16;
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32;
   #if defined(__UINT_FAST32_TYPE__)
-  SIMDE_ALIGN(16) vector __UINT_FAST32_TYPE__ altivec_u32f;
+  SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
   #else
   SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32f;
   #endif
@@ -214,14 +214,14 @@ typedef union {
    typedef v128_t simde__m128i;
    typedef v128_t simde__m128d;
 #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
-   typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128i;
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-     typedef SIMDE_POWER_ALTIVEC_VECTOR(double) simde__m128d;
-  #else
+   typedef SIMDE_POWER_ALTIVEC_VECTOR(signed long long) simde__m128i;
+   #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+   typedef SIMDE_POWER_ALTIVEC_VECTOR(double) simde__m128d;
+   #else
      typedef simde__m128d_private simde__m128d;
-  #endif
+   #endif
 #elif defined(SIMDE_VECTOR_SUBSCRIPT)
-  typedef int_fast32_t simde__m128i SIMDE_ALIGN(16) SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+  typedef int64_t simde__m128i SIMDE_ALIGN(16) SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
   typedef simde_float64 simde__m128d SIMDE_ALIGN(16) SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
 #else
   typedef simde__m128i_private simde__m128i;
@@ -289,6 +289,21 @@ simde__m128d_to_private(simde__m128d v) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float64x2_t, neon, f64)
   #endif
+#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), altivec, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
+  #endif
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(float), altivec, f32)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(double), altivec, f64)
+  #endif
 #endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
@@ -304,37 +319,22 @@ simde__m128d_to_private(simde__m128d v) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float64x2_t, neon, f64)
   #endif
+#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), altivec, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
+  #endif
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(float), altivec, f32)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(double), altivec, f64)
+  #endif
 #endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
-
-#if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector signed char, altivec, i8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector signed short, altivec, i16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector signed int, altivec, i32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector signed long long, altivec, i64)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector unsigned char, altivec, u8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector unsigned short, altivec, u16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector unsigned int, altivec, u32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector unsigned long long, altivec, u64)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector float, altivec, f32)
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector double, altivec, f64)
-  #endif /* defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) */
-#endif /* defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) */
-
-#if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector signed char, altivec, i8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector signed short, altivec, i16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector signed int, altivec, i32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector signed long long, altivec, i64)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector unsigned char, altivec, u8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector unsigned short, altivec, u16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector unsigned int, altivec, u32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector unsigned long long, altivec, u64)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector float, altivec, f32)
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector double, altivec, f64)
-  #endif /* defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) */
-#endif /* defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) */
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
@@ -906,22 +906,26 @@ simde_mm_avg_epu16 (simde__m128i a, simde__m128i b) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_mm_setzero_si128 (void) {
-#if defined(SIMDE_X86_SSE2_NATIVE)
-  return _mm_setzero_si128();
-#else
-  simde__m128i_private r_;
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setzero_si128();
+  #else
+    simde__m128i_private r_;
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  r_.neon_i32 = vdupq_n_s32(0);
-#else
-  SIMDE_VECTORIZE
-  for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-    r_.i32f[i] = 0;
-  }
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vdupq_n_s32(0);
+    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, 0));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT)
+      r_.i32 = __extension__ (__typeof__(r_.i32)) { 0, 0, 0, 0 };
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = 0;
+      }
+    #endif
 
-  return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
 #  define _mm_setzero_si128() (simde_mm_setzero_si128())
@@ -955,6 +959,12 @@ simde_mm_bslli_si128 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
 #  define simde_mm_bslli_si128(a, imm8) \
   simde__m128i_from_neon_i8(((imm8) <= 0) ? simde__m128i_to_neon_i8(a) : (((imm8) > 15) ? (vdupq_n_s8(0)) : (vextq_s8(vdupq_n_s8(0), simde__m128i_to_neon_i8(a), 16 - (imm8)))))
+#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #define simde_mm_bslli_si128(a, imm8) \
+    (__extension__ ({ \
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) simde_mm_bslli_si128_z_ = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }; \
+      simde__m128i_from_altivec_u8((imm8 < 16) ? vec_sld(simde__m128i_to_altivec_u8(a), simde_mm_bslli_si128_z_, imm8 & 15) : simde_mm_bslli_si128_z_); \
+    }))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
   #define simde_mm_bslli_si128(a, imm8) (__extension__ ({ \
     const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
@@ -988,8 +998,8 @@ simde_mm_bslli_si128 (simde__m128i a, const int imm8)
 #endif
 #define simde_mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#  define _mm_bslli_si128(a, b) simde_mm_bslli_si128(a, b)
-#  define _mm_slli_si128(a, b) simde_mm_bslli_si128(a, b)
+#  define _mm_bslli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
+#  define _mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -1013,6 +1023,12 @@ simde_mm_bsrli_si128 (simde__m128i a, const int imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
 #  define simde_mm_bsrli_si128(a, imm8) \
   simde__m128i_from_neon_i8(((imm8 < 0) || (imm8 > 15)) ? vdupq_n_s8(0) : (vextq_s8(simde__m128i_to_private(a).neon_i8, vdupq_n_s8(0), ((imm8 & 15) != 0) ? imm8 : (imm8 & 15))))
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_mm_bsrli_si128(a, imm8) \
+    (__extension__ ({ \
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) simde_mm_bslli_si128_z_ = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }; \
+      simde__m128i_from_altivec_u8((imm8 < 16) ? vec_sro(simde__m128i_to_altivec_u8(a), vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8))) : simde_mm_bslli_si128_z_); \
+    }))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
   #define simde_mm_bsrli_si128(a, imm8) (__extension__ ({ \
     const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
@@ -1266,7 +1282,7 @@ simde_mm_castsi128_ps (simde__m128i a) {
 #if defined(SIMDE_X86_SSE2_NATIVE)
   return _mm_castsi128_ps(a);
 #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
-  return a;
+  return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), a);
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   return simde__m128_from_neon_i32(simde__m128i_to_private(a).neon_i32);
 #else
@@ -1655,7 +1671,7 @@ simde_mm_cmple_pd (simde__m128d a, simde__m128d b) {
     r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f64x2_le(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmple(a_.altivec_f64, b_.altivec_f64));
   #else
     SIMDE_VECTORIZE
@@ -1808,7 +1824,7 @@ simde_mm_cmpgt_pd (simde__m128d a, simde__m128d b) {
     r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f64x2_gt(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     r_.altivec_f64 = HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpgt(a_.altivec_f64, b_.altivec_f64));
   #else
     SIMDE_VECTORIZE
@@ -1862,7 +1878,7 @@ simde_mm_cmpge_pd (simde__m128d a, simde__m128d b) {
     r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f64x2_ge(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     r_.altivec_f64 = HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpge(a_.altivec_f64, b_.altivec_f64));
   #else
     SIMDE_VECTORIZE
@@ -3276,6 +3292,8 @@ simde_mm_min_epi16 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i16 = vminq_s16(a_.neon_i16, b_.neon_i16);
+  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    r_.altivec_i16 = vec_min(a_.altivec_i16, b_.altivec_i16);
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
@@ -3303,6 +3321,8 @@ simde_mm_min_epu8 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u8 = vminq_u8(a_.neon_u8, b_.neon_u8);
+  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    r_.altivec_u8 = vec_min(a_.altivec_u8, b_.altivec_u8);
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
@@ -3328,10 +3348,14 @@ simde_mm_min_pd (simde__m128d a, simde__m128d b) {
     a_ = simde__m128d_to_private(a),
     b_ = simde__m128d_to_private(b);
 
-  SIMDE_VECTORIZE
-  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-    r_.f64[i] = (a_.f64[i] < b_.f64[i]) ? a_.f64[i] : b_.f64[i];
-  }
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    r_.altivec_f64 = vec_min(a_.altivec_f64, b_.altivec_f64);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = (a_.f64[i] < b_.f64[i]) ? a_.f64[i] : b_.f64[i];
+    }
+  #endif
 
   return simde__m128d_from_private(r_);
 #endif
@@ -3718,6 +3742,10 @@ simde_mm_mullo_epi16 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i16 = vmulq_s16(a_.neon_i16, b_.neon_i16);
+  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    (void) a_;
+    (void) b_;
+    r_.altivec_i16 = vec_mul(a_.altivec_i16, b_.altivec_i16);
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
@@ -4223,6 +4251,8 @@ simde_mm_set1_epi8 (int8_t a) {
     r_.neon_i8 = vdupq_n_s8(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i8x16_splat(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    r_.altivec_i8 = vec_splats(HEDLEY_STATIC_CAST(signed char, a));
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
@@ -4249,6 +4279,8 @@ simde_mm_set1_epi16 (int16_t a) {
     r_.neon_i16 = vdupq_n_s16(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i16x8_splat(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    r_.altivec_i16 = vec_splats(HEDLEY_STATIC_CAST(signed short, a));
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
@@ -4275,6 +4307,8 @@ simde_mm_set1_epi32 (int32_t a) {
     r_.neon_i32 = vdupq_n_s32(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i32x4_splat(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, a));
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
@@ -4301,6 +4335,8 @@ simde_mm_set1_epi64x (int64_t a) {
     r_.neon_i64 = vmovq_n_s64(a);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_i64x2_splat(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    r_.altivec_i64 = vec_splats(HEDLEY_STATIC_CAST(signed long long, a));
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
@@ -4332,25 +4368,41 @@ simde_mm_set1_epi64 (simde__m64 a) {
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_set1_epu8 (uint8_t value) {
-  return simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, value));
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return simde__m128i_from_altivec_u8(vec_splats(HEDLEY_STATIC_CAST(unsigned char, value)));
+  #else
+    return simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, value));
+  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_set1_epu16 (uint16_t value) {
-  return simde_mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, value));
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return simde__m128i_from_altivec_u16(vec_splats(HEDLEY_STATIC_CAST(unsigned short, value)));
+  #else
+    return simde_mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, value));
+  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_set1_epu32 (uint32_t value) {
-  return simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, value));
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return simde__m128i_from_altivec_u32(vec_splats(HEDLEY_STATIC_CAST(unsigned int, value)));
+  #else
+    return simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, value));
+  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_x_mm_set1_epu64 (uint64_t value) {
-  return simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, value));
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return simde__m128i_from_altivec_u64(vec_splats(HEDLEY_STATIC_CAST(unsigned long long, value)));
+  #else
+    return simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, value));
+  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -4363,6 +4415,8 @@ simde_mm_set1_pd (simde_float64 a) {
 
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f64x2_splat(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    r_.altivec_f64 = vec_splats(HEDLEY_STATIC_CAST(double, a));
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
@@ -4456,14 +4510,7 @@ simde_mm_setzero_pd (void) {
 #if defined(SIMDE_X86_SSE2_NATIVE)
   return _mm_setzero_pd();
 #else
-  simde__m128d_private r_;
-
-  SIMDE_VECTORIZE
-  for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-    r_.i32f[i] = 0;
-  }
-
-  return simde__m128d_from_private(r_);
+  return simde_mm_castsi128_pd(simde_mm_setzero_si128());
 #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
@@ -5021,15 +5068,15 @@ simde_mm_slli_epi16 (simde__m128i a, const int imm8)
     r_,
     a_ = simde__m128i_to_private(a);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-  r_.i16 = a_.i16 << (imm8 & 0xff);
-#else
-  const int s = (imm8 > HEDLEY_STATIC_CAST(int, sizeof(r_.i16[0]) * CHAR_BIT) - 1) ? 0 : imm8;
-  SIMDE_VECTORIZE
-  for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-    r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << s);
-  }
-#endif
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i16 = a_.i16 << (imm8 & 0xff);
+  #else
+    const int s = (imm8 > HEDLEY_STATIC_CAST(int, sizeof(r_.i16[0]) * CHAR_BIT) - 1) ? 0 : imm8;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << s);
+    }
+  #endif
 
   return simde__m128i_from_private(r_);
 }
@@ -5046,13 +5093,16 @@ simde_mm_slli_epi16 (simde__m128i a, const int imm8)
         if ((imm8) <= 0) {                                         \
             ret = a;                                               \
         } else if ((imm8) > 15) {                                  \
-            ret = simde__m128i_from_neon_i32(vdupq_n_s32(0));      \
+            ret = simde_mm_setzero_si128();      \
         } else {                                                   \
             ret = simde__m128i_from_neon_i16(                      \
                 vshlq_n_s16(simde__m128i_to_neon_i16(a), (imm8))); \
         }                                                          \
         ret;                                                       \
     })
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_mm_slli_epi16(a, imm8) \
+    ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sl(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
 #  define _mm_slli_epi16(a, imm8) simde_mm_slli_epi16(a, imm8)
@@ -5088,18 +5138,33 @@ simde_mm_slli_epi32 (simde__m128i a, const int imm8)
 // The above is allowed by gcc/g++ 9 with -march=armv8-a, might work on A32V8 and elsewhere but needs testing
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__) // clang can't handle the potential out of range use of imm8 even though that is handled
 #  define simde_mm_slli_epi32(a, imm8) \
-     ({                                                            \
-        simde__m128i ret;                                          \
-        if ((imm8) <= 0) {                                         \
-            ret = a;                                               \
-        } else if ((imm8) > 31) {                                  \
-            ret = simde__m128i_from_neon_i32(vdupq_n_s32(0));      \
-        } else {                                                   \
-            ret = simde__m128i_from_neon_i32(                      \
-                vshlq_n_s32(simde__m128i_to_neon_i32(a), (imm8))); \
-        }                                                          \
-        ret;                                                       \
+     ({                                                       \
+       simde__m128i ret;                                      \
+       if ((imm8) <= 0) {                                     \
+         ret = a;                                             \
+       } else if ((imm8) > 31) {                              \
+         ret = simde_mm_setzero_si128();                      \
+       } else {                                               \
+         ret = simde__m128i_from_neon_i32(                    \
+           vshlq_n_s32(simde__m128i_to_neon_i32(a), (imm8))); \
+       }                                                      \
+       ret;                                                   \
     })
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_mm_slli_epi32(a, imm8) \
+     ({                                                            \
+       simde__m128i ret;                                           \
+       if ((imm8) <= 0) {                                          \
+         ret = a;                                                  \
+       } else if ((imm8) > 31) {                                   \
+         ret = simde_mm_setzero_si128();                           \
+       } else {                                                    \
+         ret = simde__m128i_from_altivec_i32(                      \
+           vec_sl(simde__m128i_to_altivec_i32(a),                  \
+             vec_splats(HEDLEY_STATIC_CAST(unsigned int, imm8)))); \
+       }                                                           \
+       ret;                                                        \
+     })
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
 #  define _mm_slli_epi32(a, imm8) simde_mm_slli_epi32(a, imm8)
@@ -5140,7 +5205,7 @@ simde_mm_slli_epi64 (simde__m128i a, const int imm8)
         if ((imm8) <= 0) {                                         \
             ret = a;                                               \
         } else if ((imm8) > 63) {                                  \
-            ret = simde__m128i_from_neon_i32(vdupq_n_s32(0));      \
+            ret = simde_mm_setzero_si128();                        \
         } else {                                                   \
             ret = simde__m128i_from_neon_i64(                      \
                 vshlq_n_s64(simde__m128i_to_neon_i64(a), (imm8))); \
@@ -5187,13 +5252,16 @@ simde_mm_srli_epi16 (simde__m128i a, const int imm8)
         if ((imm8) <= 0) {                                         \
             ret = a;                                               \
         } else if ((imm8) > 15) {                                  \
-            ret = simde__m128i_from_neon_i32(vdupq_n_s32(0));      \
+            ret = simde_mm_setzero_si128();                        \
         } else {                                                   \
             ret = simde__m128i_from_neon_u16(                      \
                 vshrq_n_u16(simde__m128i_to_neon_u16(a), (imm8))); \
         }                                                          \
         ret;                                                       \
     })
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_mm_srli_epi16(a, imm8) \
+    ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sr(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
 #  define _mm_srli_epi16(a, imm8) simde_mm_srli_epi16(a, imm8)
@@ -5225,7 +5293,7 @@ simde_mm_srli_epi32 (simde__m128i a, const int imm8)
 #  define simde_mm_srli_epi32(a, imm8) _mm_srli_epi32(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(__clang__)
 #  define simde_mm_srli_epi32(a, imm8) \
-  simde__m128i_from_neon_u32(vshrq_n_u32(simde__m128i_to_neon_u32(a), imm8))
+     simde__m128i_from_neon_u32(vshrq_n_u32(simde__m128i_to_neon_u32(a), imm8))
 // The above is allowed by gcc/g++ 9 with -march=armv8-a, might work on A32V8 and elsewhere but needs testing
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__) // clang can't handle the potential out of range use of imm8 even though that is handled
 #  define simde_mm_srli_epi32(a, imm8) \
@@ -5234,12 +5302,27 @@ simde_mm_srli_epi32 (simde__m128i a, const int imm8)
         if ((imm8) <= 0) {                                       \
             ret = a;                                             \
         } else if ((imm8) > 31) {                                \
-            ret = simde__m128i_from_neon_i32(vdupq_n_s32(0));    \
+            ret = simde_mm_setzero_si128();                      \
         } else {                                                 \
             ret = simde__m128i_from_neon_u32(                    \
               vshrq_n_u32(simde__m128i_to_neon_u32(a), (imm8))); \
         }                                                        \
         ret;                                                     \
+    })
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+#  define simde_mm_srli_epi32(a, imm8) \
+    ({                                                                \
+        simde__m128i ret;                                             \
+        if ((imm8) <= 0) {                                            \
+            ret = a;                                                  \
+        } else if ((imm8) > 31) {                                     \
+            ret = simde_mm_setzero_si128();                           \
+        } else {                                                      \
+            ret = simde__m128i_from_altivec_i32(                      \
+              vec_sr(simde__m128i_to_altivec_i32(a),                  \
+                vec_splats(HEDLEY_STATIC_CAST(unsigned int, imm8)))); \
+        }                                                             \
+        ret;                                                          \
     })
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
@@ -5285,7 +5368,7 @@ simde_mm_srli_epi64 (simde__m128i a, const int imm8)
         if ((imm8) <= 0) {                                       \
             ret = a;                                             \
         } else if ((imm8) > 63) {                                \
-            ret = simde__m128i_from_neon_i32(vdupq_n_s32(0));    \
+            ret = simde_mm_setzero_si128();                      \
         } else {                                                 \
             ret = simde__m128i_from_neon_u64(                    \
               vshrq_n_u64(simde__m128i_to_neon_u64(a), (imm8))); \
@@ -5833,6 +5916,8 @@ simde_mm_subs_epu8 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u8 = vqsubq_u8(a_.neon_u8, b_.neon_u8);
+  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    r_.altivec_u8 = vec_subs(a_.altivec_u8, b_.altivec_u8);
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i8[0])) ; i++) {
@@ -5867,6 +5952,8 @@ simde_mm_subs_epu16 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_u16 = vqsubq_u16(a_.neon_u16, b_.neon_u16);
+  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    r_.altivec_u16 = vec_subs(a_.altivec_u16, b_.altivec_u16);
   #else
     SIMDE_VECTORIZE
     for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i++) {

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -302,6 +302,32 @@ simde__m128d_to_private(simde__m128d v) {
   #endif
 #endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
 
+#if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector signed char, altivec, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector signed short, altivec, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector signed int, altivec, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector signed long long, altivec, i64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector unsigned char, altivec, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector unsigned short, altivec, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector unsigned int, altivec, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector unsigned long long, altivec, u64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector float, altivec, f32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector double, altivec, f64)
+#endif /* defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) */
+
+#if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector signed char, altivec, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector signed short, altivec, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector signed int, altivec, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector signed long long, altivec, i64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector unsigned char, altivec, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector unsigned short, altivec, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector unsigned int, altivec, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector unsigned long long, altivec, u64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector float, altivec, f32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector double, altivec, f64)
+#endif /* defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) */
+
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128i
 simde_mm_add_epi8 (simde__m128i a, simde__m128i b) {

--- a/simde/x86/sse2.h
+++ b/simde/x86/sse2.h
@@ -215,7 +215,11 @@ typedef union {
    typedef v128_t simde__m128d;
 #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
    typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128i;
-   typedef SIMDE_POWER_ALTIVEC_VECTOR(double) simde__m128d;
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+     typedef SIMDE_POWER_ALTIVEC_VECTOR(double) simde__m128d;
+  #else
+     typedef simde__m128d_private simde__m128d;
+  #endif
 #elif defined(SIMDE_VECTOR_SUBSCRIPT)
   typedef int_fast32_t simde__m128i SIMDE_ALIGN(16) SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
   typedef simde_float64 simde__m128d SIMDE_ALIGN(16) SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
@@ -312,7 +316,9 @@ simde__m128d_to_private(simde__m128d v) {
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector unsigned int, altivec, u32)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector unsigned long long, altivec, u64)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector float, altivec, f32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector double, altivec, f64)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, vector double, altivec, f64)
+  #endif /* defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) */
 #endif /* defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) */
 
 #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
@@ -325,7 +331,9 @@ simde__m128d_to_private(simde__m128d v) {
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector unsigned int, altivec, u32)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector unsigned long long, altivec, u64)
   SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector float, altivec, f32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector double, altivec, f64)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, vector double, altivec, f64)
+  #endif /* defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) */
 #endif /* defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) */
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -434,7 +442,7 @@ simde_mm_add_epi64 (simde__m128i a, simde__m128i b) {
 
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     r_.neon_i64 = vaddq_s64(a_.neon_i64, b_.neon_i64);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     r_.altivec_i64 = vec_add(a_.altivec_i64, b_.altivec_i64);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i64 = a_.i64 + b_.i64;
@@ -467,7 +475,7 @@ simde_mm_add_pd (simde__m128d a, simde__m128d b) {
   r_.neon_f64 = vaddq_f64(a_.neon_f64, b_.neon_f64);
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   r_.wasm_v128 = wasm_f64x2_add(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
   r_.altivec_f64 = vec_add(a_.altivec_f64, b_.altivec_f64);
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
   r_.f64 = a_.f64 + b_.f64;
@@ -498,7 +506,7 @@ simde_mm_move_sd (simde__m128d a, simde__m128d b) {
 
 #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
   r_.neon_f64 = vsetq_lane_f64(vgetq_lane_f64(b_.neon_f64, 0), a_.neon_f64, 0);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
   SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) m = {
     16, 17, 18, 19, 20, 21, 22, 23,
      8,  9, 10, 11, 12, 13, 14, 15
@@ -708,7 +716,7 @@ simde_mm_and_pd (simde__m128d a, simde__m128d b) {
   r_.neon_i32 = vandq_s32(a_.neon_i32, b_.neon_i32);
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
   r_.wasm_v128 = wasm_v128_and(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
   r_.altivec_f64 = vec_and(a_.altivec_f64, b_.altivec_f64);
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
   r_.i32f = a_.i32f & b_.i32f;
@@ -1385,7 +1393,7 @@ simde_mm_cmpeq_pd (simde__m128d a, simde__m128d b) {
     r_.neon_u64 = vceqq_s64(b_.neon_i64, a_.neon_i64);
   #elif defined(SIMDE_WASM_SIMD128_NATIVE)
     r_.wasm_v128 = wasm_f64x2_eq(a_.wasm_v128, b_.wasm_v128);
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpeq(a_.altivec_f64, b_.altivec_f64));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
@@ -2409,7 +2417,7 @@ simde_mm_cvtsi128_si64 (simde__m128i a) {
   #endif
 #else
   simde__m128i_private a_ = simde__m128i_to_private(a);
-#if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && !defined(HEDLEY_IBM_VERSION)
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) && !defined(HEDLEY_IBM_VERSION)
   return vec_extract(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long), a_.i64), 0);
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   return vgetq_lane_s64(a_.neon_i64, 0);
@@ -3424,7 +3432,7 @@ simde_mm_max_pd (simde__m128d a, simde__m128d b) {
       a_ = simde__m128d_to_private(a),
       b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
       r_.altivec_f64 = vec_max(a_.altivec_f64, b_.altivec_f64);
     #else
       SIMDE_VECTORIZE
@@ -5399,7 +5407,7 @@ simde_mm_storel_epi64 (simde__m128i* mem_addr, simde__m128i a) {
 
     #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
       tmp = vgetq_lane_s64(a_.neon_i64, 0);
-    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
       #if defined(SIMDE_BUG_GCC_95227)
         (void) a_;
       #endif

--- a/simde/x86/sse4.1.h
+++ b/simde/x86/sse4.1.h
@@ -313,7 +313,7 @@ simde_x_mm_blendv_epi64 (simde__m128i a, simde__m128i b, simde__m128i mask) {
 #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
   mask_.u64 = vcltq_s64(mask_.i64, vdupq_n_s64(UINT64_C(0)));
   r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
   r_.altivec_i64 = vec_sel(a_.altivec_i64, b_.altivec_i64,
                            vec_cmplt(mask_.altivec_i64, vec_splats(HEDLEY_STATIC_CAST(signed long long, 0))));
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
@@ -1042,7 +1042,7 @@ simde_mm_extract_epi64 (simde__m128i a, const int imm8)
   simde__m128i_private
     a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
     #if defined(SIMDE_BUG_GCC_95227)
       (void) a_;
       (void) imm8;
@@ -1056,7 +1056,7 @@ simde_mm_extract_epi64 (simde__m128i a, const int imm8)
 #  define simde_mm_extract_epi64(a, imm8) _mm_extract_epi64(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
 #  define simde_mm_extract_epi64(a, imm8) vgetq_lane_s64(simde__m128i_to_private(a).neon_i64, imm8)
-#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
 #  define simde_mm_extract_epi64(a, imm8) HEDLEY_STATIC_CAST(int64_t, vec_extract(simde__m128i_to_private(a).altivec_i64, imm8))
 #endif
 #if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)

--- a/simde/x86/sse4.1.h
+++ b/simde/x86/sse4.1.h
@@ -72,6 +72,21 @@ simde_mm_blend_epi16 (simde__m128i a, simde__m128i b, const int imm8)
            uint16x8_t _mask_vec = vld1q_u16(_mask);  \
            simde__m128i_from_neon_u16(vbslq_u16(_mask_vec, simde__m128i_to_neon_u16(b), simde__m128i_to_neon_u16(a))); \
        }))
+#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#  define simde_mm_blend_epi16(a, b, imm8)      \
+     (__extension__ ({ \
+           const vector unsigned short _mask = {      \
+               ((imm8) & (1 << 0)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 1)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 2)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 3)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 4)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 5)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 6)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 7)) ? 0xFFFF : 0x0000  \
+           };                                         \
+           simde__m128i_from_altivec_u16(vec_sel(simde__m128i_to_altivec_u16(a), simde__m128i_to_altivec_u16(b), _mask)); \
+       }))
 #endif
 #if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
 #  define _mm_blend_epi16(a, b, imm8) simde_mm_blend_epi16(a, b, imm8)
@@ -94,6 +109,25 @@ simde_mm_blend_pd (simde__m128d a, simde__m128d b, const int imm8)
 }
 #if defined(SIMDE_X86_SSE4_1_NATIVE)
 #  define simde_mm_blend_pd(a, b, imm8) _mm_blend_pd(a, b, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_blend_pd(a, b, imm8) \
+     (__extension__ ({ \
+           const uint64_t _mask[2] = {               \
+               ((imm8) & (1 << 0)) ? UINT64_MAX : 0, \
+               ((imm8) & (1 << 1)) ? UINT64_MAX : 0  \
+           };                                        \
+           uint64x2_t _mask_vec = vld1q_u64(_mask);  \
+           simde__m128d_from_neon_f64(vbslq_f64(_mask_vec, simde__m128d_to_neon_f64(b), simde__m128d_to_neon_f64(a))); \
+       }))
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#  define simde_mm_blend_pd(a, b, imm8)         \
+     (__extension__ ({ \
+           const vector unsigned long long _mask = { \
+               ((imm8) & (1 << 0)) ? UINT64_MAX : 0, \
+               ((imm8) & (1 << 1)) ? UINT64_MAX : 0  \
+           };                                        \
+           simde__m128d_from_altivec_f64(vec_sel(simde__m128d_to_altivec_f64(a), simde__m128d_to_altivec_f64(b), _mask)); \
+       }))
 #endif
 #if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
 #  define _mm_blend_pd(a, b, imm8) simde_mm_blend_pd(a, b, imm8)
@@ -116,6 +150,29 @@ simde_mm_blend_ps (simde__m128 a, simde__m128 b, const int imm8)
 }
 #if defined(SIMDE_X86_SSE4_1_NATIVE)
 #  define simde_mm_blend_ps(a, b, imm8) _mm_blend_ps(a, b, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_blend_ps(a, b, imm8) \
+     (__extension__ ({ \
+           const uint32_t _mask[4] = {               \
+               ((imm8) & (1 << 0)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 1)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 2)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 3)) ? UINT32_MAX : 0  \
+           };                                        \
+           uint32x4_t _mask_vec = vld1q_u32(_mask);  \
+           simde__m128_from_neon_f32(vbslq_f32(_mask_vec, simde__m128_to_neon_f32(b), simde__m128_to_neon_f32(a))); \
+       }))
+#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+#  define simde_mm_blend_ps(a, b, imm8) \
+     (__extension__ ({ \
+           const vector unsigned int _mask = {       \
+               ((imm8) & (1 << 0)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 1)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 2)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 3)) ? UINT32_MAX : 0  \
+           };                                        \
+           simde__m128_from_altivec_f32(vec_sel(simde__m128_to_altivec_f32(a), simde__m128_to_altivec_f32(b), _mask)); \
+       }))
 #endif
 #if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
 #  define _mm_blend_ps(a, b, imm8) simde_mm_blend_ps(a, b, imm8)
@@ -137,6 +194,8 @@ simde_mm_blendv_epi8 (simde__m128i a, simde__m128i b, simde__m128i mask) {
     // Use a signed shift right to create a mask with the sign bit
     mask_.neon_i8 = vshrq_n_s8(mask_.neon_i8, 7);
     r_.neon_i8 = vbslq_s8(mask_.neon_u8, b_.neon_i8, a_.neon_i8);
+  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    r_.altivec_i8 = vec_sel(a_.altivec_i8, b_.altivec_i8, vec_cmplt(mask_.altivec_i8, vec_splat_s8(0)));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     /* https://software.intel.com/en-us/forums/intel-c-compiler/topic/850087 */
     #if defined(HEDLEY_INTEL_VERSION_CHECK)
@@ -178,6 +237,8 @@ simde_x_mm_blendv_epi16 (simde__m128i a, simde__m128i b, simde__m128i mask) {
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   mask_ = simde__m128i_to_private(simde_mm_cmplt_epi16(mask, simde_mm_setzero_si128()));
   r_.neon_i16 = vbslq_s16(mask_.neon_u16, b_.neon_i16, a_.neon_i16);
+#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  r_.altivec_i16 = vec_sel(a_.altivec_i16, b_.altivec_i16, vec_cmplt(mask_.altivec_i16, vec_splat_s16(0)));
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
   #if defined(HEDLEY_INTEL_VERSION_CHECK)
     __typeof__(mask_.i16) z = { 0, 0, 0, 0, 0, 0, 0, 0 };
@@ -214,6 +275,8 @@ simde_x_mm_blendv_epi32 (simde__m128i a, simde__m128i b, simde__m128i mask) {
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
   mask_ = simde__m128i_to_private(simde_mm_cmplt_epi32(mask, simde_mm_setzero_si128()));
   r_.neon_i32 = vbslq_s32(mask_.neon_u32, b_.neon_i32, a_.neon_i32);
+#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  r_.altivec_i32 = vec_sel(a_.altivec_i32, b_.altivec_i32, vec_cmplt(mask_.altivec_i32, vec_splat_s32(0)));
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
   #if defined(HEDLEY_INTEL_VERSION_CHECK)
     __typeof__(mask_.i32) z = { 0, 0, 0, 0 };
@@ -250,6 +313,9 @@ simde_x_mm_blendv_epi64 (simde__m128i a, simde__m128i b, simde__m128i mask) {
 #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
   mask_.u64 = vcltq_s64(mask_.i64, vdupq_n_s64(UINT64_C(0)));
   r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
+#elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  r_.altivec_i64 = vec_sel(a_.altivec_i64, b_.altivec_i64,
+                           vec_cmplt(mask_.altivec_i64, vec_splats(HEDLEY_STATIC_CAST(signed long long, 0))));
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
   #if defined(HEDLEY_INTEL_VERSION_CHECK)
     __typeof__(mask_.i64) z = { 0, 0 };
@@ -313,7 +379,7 @@ simde_mm_round_pd (simde__m128d a, int rounding)
 
   switch (rounding & ~SIMDE_MM_FROUND_NO_EXC) {
     case SIMDE_MM_FROUND_CUR_DIRECTION:
-      #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
         r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_round(a_.altivec_f64));
       #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && 0
         r_.neon_f64 = vrndiq_f64(a_.neon_f64);
@@ -328,7 +394,7 @@ simde_mm_round_pd (simde__m128d a, int rounding)
       break;
 
     case SIMDE_MM_FROUND_TO_NEAREST_INT:
-      #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
         r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_round(a_.altivec_f64));
       #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && 0
         r_.neon_f64 = vrndaq_f64(a_.neon_f64);
@@ -343,7 +409,7 @@ simde_mm_round_pd (simde__m128d a, int rounding)
       break;
 
     case SIMDE_MM_FROUND_TO_NEG_INF:
-      #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
         r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_floor(a_.altivec_f64));
       #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && 0
         r_.neon_f64 = vrndmq_f64(a_.neon_f64);
@@ -356,7 +422,7 @@ simde_mm_round_pd (simde__m128d a, int rounding)
       break;
 
     case SIMDE_MM_FROUND_TO_POS_INF:
-      #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
         r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_ceil(a_.altivec_f64));
       #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && 0
         r_.neon_f64 = vrndpq_f64(a_.neon_f64);
@@ -371,7 +437,7 @@ simde_mm_round_pd (simde__m128d a, int rounding)
       break;
 
     case SIMDE_MM_FROUND_TO_ZERO:
-      #if defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
         r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_trunc(a_.altivec_f64));
       #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && 0
         r_.neon_f64 = vrndq_f64(a_.neon_f64);

--- a/simde/x86/sse4.2.h
+++ b/simde/x86/sse4.2.h
@@ -168,7 +168,7 @@ simde_mm_cmpgt_epi64 (simde__m128i a, simde__m128i b) {
     // a_hi > b_hi || (a_lo > b_lo && a_hi == b_hi)
     int64x2_t ret = vorrq_s64(gt_hi, vandq_s64(gt_lo, eq_hi));
     r_.neon_i64 = ret;
-  #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
     r_.altivec_u64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpgt(a_.altivec_i64, b_.altivec_i64));
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
     r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), a_.i64 > b_.i64);


### PR DESCRIPTION
With PPC64 on qemu there is a problem with _mm_movemask_epi8. I think it is a qemu bug. Have you seen it before?